### PR TITLE
ProfanityRemoverAgent: Improve prompt and fix status bug

### DIFF
--- a/backend/director/agents/profanity_remover.py
+++ b/backend/director/agents/profanity_remover.py
@@ -67,12 +67,12 @@ class ProfanityRemoverAgent(BaseAgent):
         """
         try:
             beep_audio_id = beep_audio_id or BEEP_AUDIO_ID
-            error_message = (
-                "Please provide the beep_audio_id, or set up BEEP_AUDIO_ID in the .env file located in the backend directory."
-                "Notify user this verbatum in summary as well since it isn't displayed to them: If you don’t have a beep sound ready, you can use the audio from https://www.youtube.com/watch?v=GvXbEO5Kbgc YouTube link. Upload it as audio, obtain the audio ID, and set it as BEEP_AUDIO_ID in your .env file.'"
-                "Remember to add above line in summary."
-            )
             if not beep_audio_id:
+                error_message = (
+                    "Please provide the beep_audio_id, or set up BEEP_AUDIO_ID in the .env file located in the backend directory."
+                    "Notify user this verbatum in summary as well since it isn't displayed to them: If you don’t have a beep sound ready, you can use the audio from https://www.youtube.com/watch?v=GvXbEO5Kbgc YouTube link. Upload it as audio, obtain the audio ID, and set it as BEEP_AUDIO_ID in your .env file.'"
+                    "Remember to add above line in summary."
+                )
                 return AgentResponse(
                     status=AgentStatus.ERROR,
                     message=error_message,

--- a/backend/director/agents/profanity_remover.py
+++ b/backend/director/agents/profanity_remover.py
@@ -67,10 +67,15 @@ class ProfanityRemoverAgent(BaseAgent):
         """
         try:
             beep_audio_id = beep_audio_id or BEEP_AUDIO_ID
+            error_message = (
+                "Please provide the beep_audio_id, or set up BEEP_AUDIO_ID in the .env file located in the backend directory."
+                "Notify user this verbatum in summary as well since it isn't displayed to them: If you don’t have a beep sound ready, you can use the audio from https://www.youtube.com/watch?v=GvXbEO5Kbgc YouTube link. Upload it as audio, obtain the audio ID, and set it as BEEP_AUDIO_ID in your .env file.'"
+                "Remember to add above line in summary."
+            )
             if not beep_audio_id:
                 return AgentResponse(
-                    status=AgentStatus.failed,
-                    message="Please provide the beep_audio_id or setup BEEP_AUDIO_ID in .env of backend directory.",
+                    status=AgentStatus.ERROR,
+                    message=error_message,
                 )
             self.output_message.actions.append("Started process to remove profanity..")
             video_content = VideoContent(


### PR DESCRIPTION
If the `BEEP_AUDIO_ID` is not set, the Reasoning Engine with improved prompt will respond along these lines:

> The profanity remover agent couldn't process your request because it requires a beep audio ID, which wasn't provided. You'll need to upload a beep sound, obtain its audio ID, and set it as BEEP_AUDIO_ID in the .env file. You can use a beep sound from [this YouTube link](https://www.youtube.com/watch?v=GvXbEO5Kbgc) if needed.


Users can request an upload of the default beep or an alternative URL to obtain the beep_audio_id for configuration as followup prompt.