### PR TITLE
Add Python 3.13 Support to Forked openai-function-calling and Replace Original Package

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,7 +4,6 @@ Flask==3.0.3
 Flask-SocketIO==5.3.6
 Flask-Cors==4.0.1
 openai==1.42.0
-openai-function-calling==2.2.0
 pydantic==2.8.2
 pydantic-settings==2.4.0
 python-dotenv==1.0.1
@@ -12,3 +11,5 @@ replicate==1.0.1
 yt-dlp==2024.10.7
 videodb==0.2.5
 slack_sdk==3.33.2
+
+git+https://github.com/0xrohitgarg/openai-function-calling.git#egg=openai-function-calling


### PR DESCRIPTION
## Add Python 3.13 Support via Forked `openai-function-calling` and Replace Original Package  



This pull request resolves a compatibility issue with the `openai-function-calling` package, which currently supports Python versions `>=3.9, <3.13`. Users with Python 3.13 face installation and runtime issues due to this limitation.  

### Changes Implemented:  
1. **Forked Repository**: We forked the `openai-function-calling` repository and updated it to add support for Python 3.13.  
2. **Temporary Replacement**: The forked repository is now being used in place of the original package until the issue is addressed upstream.  

### Related Issue:  
The compatibility problem has been reported in the original repository:  
[Issue #24: Python 3.13 not supported](https://github.com/jakecyr/openai-function-calling/issues/24)  

### Forked Repository:  
[0xrohitgarg/openai-function-calling](https://github.com/0xrohitgarg/openai-function-calling)  

This fix ensures smooth functionality for users with Python 3.13 and avoids interruptions while waiting for the original repository to implement an official resolution.
