### PR TITLE
tempfix: issue 65

### DIFF
--- a/backend/director/agents/dubbing.py
+++ b/backend/director/agents/dubbing.py
@@ -155,7 +155,7 @@ class DubbingAgent(BaseAgent):
 
             return AgentResponse(
                 status=AgentStatus.SUCCESS,
-                message=f"Successfully dubbed video '{video['name']}' to {target_language}",
+                message=f"Successfully dubbed video '{video['name']}' to {target_language} which has video_id {dubbed_video['id']} ",
                 data={
                     "stream_url": dubbed_video["stream_url"],
                     "video_id": dubbed_video["id"],


### PR DESCRIPTION
This temporarily fixes #65 by adding some context about the VideoID of dubbed video in the return message.
Ideally reasoning engine should be able to figure it out, because dubbing agent is dumping video id in the data of return object