### PR TITLE
Send download link and rename summary agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .env
+.env.backup
 venv
 .venv
 .vscode

--- a/backend/director/agents/download.py
+++ b/backend/director/agents/download.py
@@ -44,6 +44,8 @@ class DownloadAgent(BaseAgent):
                 text_content.status_message = "Here is the download link"
                 self.output_message.publish()
             else:
+                text_content.status = MsgStatus.error
+                text_content.status_message = "Download failed"
                 return AgentResponse(
                     status=AgentStatus.ERROR,
                     message=f"Downloda failed with {download_response}",

--- a/backend/director/agents/download.py
+++ b/backend/director/agents/download.py
@@ -1,7 +1,7 @@
 import logging
 
 from director.agents.base import BaseAgent, AgentResponse, AgentStatus
-from director.core.session import Session
+from director.core.session import Session, TextContent, MsgStatus
 from director.tools.videodb_tool import VideoDBTool
 
 logger = logging.getLogger(__name__)
@@ -14,9 +14,7 @@ class DownloadAgent(BaseAgent):
         self.parameters = self.get_parameters()
         super().__init__(session=session, **kwargs)
 
-    def run(
-        self, stream_link: str, name: str = None, *args, **kwargs
-    ) -> AgentResponse:
+    def run(self, stream_link: str, name: str = None, *args, **kwargs) -> AgentResponse:
         """
         Downloads the video from the given stream link.
 
@@ -30,13 +28,33 @@ class DownloadAgent(BaseAgent):
         :rtype: AgentResponse
         """
         try:
+            text_content = TextContent(agent_name=self.agent_name)
+            text_content.status_message = "Downloading.."
+            self.output_message.content.append(text_content)
+            self.output_message.push_update()
             videodb_tool = VideoDBTool()
             download_response = videodb_tool.download(stream_link, name)
+            if download_response.get("status") == "done":
+                download_url = download_response.get("download_url")
+                name = download_response.get("name")
+                text_content.text = (
+                    f"<a href='{download_url}' target='_blank'>{name}</a>"
+                )
+                text_content.status = MsgStatus.success
+                text_content.status_message = "Here is the download link"
+                self.output_message.publish()
+            else:
+                return AgentResponse(
+                    status=AgentStatus.ERROR,
+                    message=f"Downloda failed with {download_response}",
+                )
         except Exception as e:
+            text_content.status = MsgStatus.error
+            text_content.status_message = "Download failed"
             logger.exception(f"error in {self.agent_name} agent: {e}")
             return AgentResponse(status=AgentStatus.ERROR, message=str(e))
         return AgentResponse(
             status=AgentStatus.SUCCESS,
-            message="Download successful but not dispalyed, send it in the summary.",
+            message="Download successful.",
             data=download_response,
         )

--- a/backend/director/agents/summarize_video.py
+++ b/backend/director/agents/summarize_video.py
@@ -8,9 +8,9 @@ from director.tools.videodb_tool import VideoDBTool
 logger = logging.getLogger(__name__)
 
 
-class VideoSummaryAgent(BaseAgent):
+class SummarizeVideoAgent(BaseAgent):
     def __init__(self, session=None, **kwargs):
-        self.agent_name = "video_summary"
+        self.agent_name = "summarize_video"
         self.description = "This is an agent to summarize the given video of VideoDB, if the user wants a certain kind of summary the prompt is required."
         self.llm = OpenAI()
         self.parameters = self.get_parameters()

--- a/backend/director/handler.py
+++ b/backend/director/handler.py
@@ -1,10 +1,8 @@
 import os
 import logging
 
-from dotenv import dotenv_values
-
 from director.agents.thumbnail import ThumbnailAgent
-from director.agents.video_summary import VideoSummaryAgent
+from director.agents.summarize_video import SummarizeVideoAgent
 from director.agents.download import DownloadAgent
 from director.agents.pricing import PricingAgent
 from director.agents.upload import UploadAgent
@@ -38,7 +36,7 @@ class ChatHandler:
         # Register the agents here
         self.agents = [
             ThumbnailAgent,
-            VideoSummaryAgent,
+            SummarizeVideoAgent,
             DownloadAgent,
             PricingAgent,
             UploadAgent,


### PR DESCRIPTION
- Sending the download link through agent instead of relying on RE solves https://github.com/video-db/Director/issues/73
- Improved name of summary agent from `video_summary` to `summarize_video` 