### PR TITLE
added feature to stop generation of response.

### DIFF
--- a/backend/director/core/session.py
+++ b/backend/director/core/session.py
@@ -175,6 +175,9 @@ class OutputMessage(BaseMessage):
 
     def push_update(self):
         """Publish the message to the socket."""
+        if StopManager.should_stop(self.session_id):
+            print(f"Update halted for session {self.session_id}")
+            return
         try:
             emit("chat", self.model_dump(), namespace="/chat")
         except Exception as e:
@@ -231,6 +234,26 @@ class ContextMessage(BaseModel):
     def from_json(cls, json_data):
         """Create the context message from the json data."""
         return cls(**json_data)
+
+class StopManager:
+    """Central manager to track stop signals for agents."""
+    stop_flags = {}
+
+    @classmethod
+    def initialize_flag(cls, agent_name: str):
+        """Initialize a stop flag for the given agent."""
+        cls.stop_flags[agent_name] = False
+
+    @classmethod
+    def stop_agent(cls, agent_name: str):
+        """Set the stop flag for the given agent."""
+        if agent_name in cls.stop_flags:
+            cls.stop_flags[agent_name] = True
+
+    @classmethod
+    def should_stop(cls, agent_name: str) -> bool:
+        """Check if the agent should stop."""
+        return cls.stop_flags.get(agent_name, False)
 
 
 class Session:

--- a/backend/director/entrypoint/api/routes.py
+++ b/backend/director/entrypoint/api/routes.py
@@ -3,6 +3,7 @@ import os
 from flask import Blueprint, request, current_app as app
 
 from director.db import load_db
+from director.core.session import StopManager
 from director.handler import ChatHandler, SessionHandler, VideoDBHandler, ConfigHandler
 
 
@@ -22,6 +23,13 @@ def agent():
     )
     return chat_handler.agents_list()
 
+@agent_bp.route("/stop", methods=["POST"])
+def stop_agent():
+    agent_name = request.json.get("agent_name")  
+    if not agent_name:
+        return {"message": "Agent name is required."}, 400
+    StopManager.stop_agent(agent_name)  
+    return {"message": f"Agent {agent_name} generation canceled."}, 200
 
 @session_bp.route("/", methods=["GET"], strict_slashes=False)
 def get_sessions():


### PR DESCRIPTION
This PR is in reference to issue #84, which introduces a feature that allows users to stop agent response generation. This allows users to edit prompts and resubmit without waiting for long tasks to complete.

![image](https://github.com/user-attachments/assets/96be4d24-6b5e-453a-ade5-919afb7135f6)
![image](https://github.com/user-attachments/assets/2b0e6413-1aab-448b-bea2-0bd533cf8fc2)

Currently the agent name is required as a parameter to stop response. This is for the testing phase only.

Let me know if any changes are required or if I should start working on the frontend functionality, where users can manually cancel the agent's response.
