### PR TITLE
add collection_id as required param in upload agent

### DIFF
--- a/backend/director/agents/upload.py
+++ b/backend/director/agents/upload.py
@@ -40,7 +40,7 @@ UPLOAD_AGENT_PARAMETERS = {
             "description": "Collection ID to upload the content",
         },
     },
-    "required": ["url", "media_type"],
+    "required": ["url", "media_type", "collection_id"],
 }
 
 

--- a/backend/director/tools/videodb_tool.py
+++ b/backend/director/tools/videodb_tool.py
@@ -178,8 +178,6 @@ class VideoDBTool:
             video = self.collection.get_video(video_id)
             search_resuls = video.search(query=query, index_type=index_type, **kwargs)
         else:
-            if index_type == IndexType.scene:
-                kwargs.pop("scene_index_id", None)
             search_resuls = self.collection.search(
                 query=query, index_type=index_type, **kwargs
             )

--- a/backend/director/tools/videodb_tool.py
+++ b/backend/director/tools/videodb_tool.py
@@ -178,6 +178,7 @@ class VideoDBTool:
             video = self.collection.get_video(video_id)
             search_resuls = video.search(query=query, index_type=index_type, **kwargs)
         else:
+            kwargs.pop("scene_index_id", None)
             search_resuls = self.collection.search(
                 query=query, index_type=index_type, **kwargs
             )


### PR DESCRIPTION
Earlier, collection_id was an optional parameter in the Upload agent's parameters, which sometimes caused the Reasoning engine to omit it.

With this change, collection_id is now a required parameter, which should resolve the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The upload process now requires a `collection_id` parameter, enhancing the upload functionality.
  
- **Bug Fixes**
	- Improved error handling during uploads, ensuring better logging of issues.
  
- **Improvements**
	- Simplified logic in the video database tool's search functionality, enhancing query construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->