### PR TITLE
Skip Translation if Source Language Matches Target Language (Fixes #42)

### DIFF
--- a/backend/director/agents/subtitle.py
+++ b/backend/director/agents/subtitle.py
@@ -156,15 +156,6 @@ class SubtitleAgent(BaseAgent):
             role=RoleTypes.user,
         )
 
-        # detection_response = self.llm.chat_completions(
-        #     [detection_message.to_llm_msg()],
-        #     response_format={"type": "json_object"},
-        # )
-
-        # result = json.loads(detection_response.content)
-        # logger.info(f"Detected language: {result['detected_language'].lower()}")
-        # return result["detected_language"].lower()
-
         try:
             detection_response = self.llm.chat_completions(
                 [detection_message.to_llm_msg()],

--- a/backend/director/agents/subtitle.py
+++ b/backend/director/agents/subtitle.py
@@ -16,7 +16,7 @@ from director.llm import get_default_llm
 
 from videodb.asset import VideoAsset, TextAsset, TextStyle
 from videodb.exceptions import InvalidRequestError
-from videodb._constants import Segmenter
+from videodb import Segmenter
 
 logger = logging.getLogger(__name__)
 

--- a/backend/director/agents/subtitle.py
+++ b/backend/director/agents/subtitle.py
@@ -225,10 +225,20 @@ class SubtitleAgent(BaseAgent):
                 status=MsgStatus.progress,
                 status_message="Processing...",
             )
-            self.output_message.content.append(video_content)
+            # self.output_message.content.append(video_content)
             self.output_message.push_update()
 
-            transcript = self.videodb_tool.get_transcript(video_id, text=False)
+
+            try:
+                transcript = self.videodb_tool.get_transcript(video_id, text=False)
+                self.output_message.content.append(video_content)
+                self.output_message.push_update()
+
+            except Exception as e:
+                logger.exception(f"Error in {self.agent_name} agent: {e}")
+                self.output_message.publish()
+                return AgentResponse(status=AgentStatus.ERROR, message=str(e))
+
             compact_transcript = self.get_compact_transcript(transcript=transcript)
 
             self.output_message.actions.append("Detecting source language of the video")
@@ -242,7 +252,7 @@ class SubtitleAgent(BaseAgent):
                     "Source language matches target language. No translation needed"
                 )
                 self.output_message.actions.append(
-                    f"Source language ({source_language}) matches target language. No translation needed."
+                    f"Source language ({source_language}) matches target language.."
                 )
                 self.output_message.push_update()
 

--- a/backend/director/agents/subtitle.py
+++ b/backend/director/agents/subtitle.py
@@ -246,7 +246,6 @@ class SubtitleAgent(BaseAgent):
             source_language = self.detect_language(compact_transcript)
             logger.info(f"Detected source language: {source_language}")
 
-            # Check if translation is needed
             if source_language == target_language:
                 logger.info(
                     "Source language matches target language. No translation needed"
@@ -256,7 +255,6 @@ class SubtitleAgent(BaseAgent):
                 )
                 self.output_message.push_update()
 
-                # Convert transcript directly to subtitle format without translation
                 subtitles = []
                 current_subtitle = {"start": None, "end": None, "text": []}
 

--- a/backend/director/tools/videodb_tool.py
+++ b/backend/director/tools/videodb_tool.py
@@ -6,6 +6,7 @@ import logging
 from videodb import SearchType, SubtitleStyle, IndexType, SceneExtractionType
 from videodb.timeline import Timeline
 from videodb.asset import VideoAsset, ImageAsset
+from videodb._constants import Segmenter
 
 
 class VideoDBTool:
@@ -213,12 +214,12 @@ class VideoDBTool:
             "url": image.url,
         }
 
-    def get_transcript(self, video_id: str, text=True):
+    def get_transcript(self, video_id: str, text=True, segmenter=Segmenter.word):
         video = self.collection.get_video(video_id)
         if text:
             transcript = video.get_transcript_text()
         else:
-            transcript = video.get_transcript()
+            transcript = video.get_transcript(segmenter=segmenter)
         return transcript
 
     def index_spoken_words(self, video_id: str):

--- a/backend/director/tools/videodb_tool.py
+++ b/backend/director/tools/videodb_tool.py
@@ -6,7 +6,7 @@ import logging
 from videodb import SearchType, SubtitleStyle, IndexType, SceneExtractionType
 from videodb.timeline import Timeline
 from videodb.asset import VideoAsset, ImageAsset
-from videodb._constants import Segmenter
+from videodb import Segmenter
 
 
 class VideoDBTool:

--- a/backend/director/tools/videodb_tool.py
+++ b/backend/director/tools/videodb_tool.py
@@ -6,7 +6,6 @@ import logging
 from videodb import SearchType, SubtitleStyle, IndexType, SceneExtractionType
 from videodb.timeline import Timeline
 from videodb.asset import VideoAsset, ImageAsset
-from videodb import Segmenter
 
 
 class VideoDBTool:
@@ -214,12 +213,15 @@ class VideoDBTool:
             "url": image.url,
         }
 
-    def get_transcript(self, video_id: str, text=True, segmenter=Segmenter.word):
+    def get_transcript(self, video_id: str, text=True, length=None):
         video = self.collection.get_video(video_id)
         if text:
             transcript = video.get_transcript_text()
         else:
-            transcript = video.get_transcript(segmenter=segmenter)
+            if length:
+                transcript = video.get_transcript(length=length)
+            else:
+                transcript = video.get_transcript()
         return transcript
 
     def index_spoken_words(self, video_id: str):


### PR DESCRIPTION
This PR introduces a check to skip subtitle translation when the detected source language matches the target language.

- Added detect_language() method to determine the original language of the transcript.
- Updated run() method to compare the source and target languages before proceeding with translation.
- If both languages are the same, subtitles are directly formatted without invoking the translation model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Transcript samples are now automatically checked to detect their language.
	- Subtitles are generated directly without translation if the source and target languages match, streamlining the subtitle process.
	- Enhanced flexibility in transcript retrieval by allowing specification of a length for transcript retrieval.

- **Bug Fixes**
	- Enhanced error handling for transcript retrieval, ensuring exceptions are logged appropriately.

- **Improvements**
	- Updated output message actions to reflect the new steps in subtitle processing.
	- Improved handling of transcript retrieval logic based on the provided length parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->