### PR TITLE
fix: move psycopg2 imports to runtime

### DIFF
--- a/backend/director/db/postgres/db.py
+++ b/backend/director/db/postgres/db.py
@@ -2,8 +2,6 @@ import json
 import time
 import logging
 import os
-import psycopg2
-from psycopg2.extras import RealDictCursor
 from typing import List
 
 from director.constants import DBType
@@ -16,6 +14,14 @@ logger = logging.getLogger(__name__)
 class PostgresDB(BaseDB):
     def __init__(self):
         """Initialize PostgreSQL connection using environment variables."""
+
+        try:
+            import psycopg2
+            from psycopg2.extras import RealDictCursor
+
+        except ImportError:
+            raise ImportError("Please install psycopg2 library to use PostgreSQL.")
+
         self.db_type = DBType.POSTGRES
         self.conn = psycopg2.connect(
             dbname=os.getenv("POSTGRES_DB", "postgres"),

--- a/backend/director/db/postgres/initialize.py
+++ b/backend/director/db/postgres/initialize.py
@@ -1,5 +1,4 @@
 import os
-import psycopg2
 import logging
 from dotenv import load_dotenv
 
@@ -46,14 +45,22 @@ CREATE TABLE IF NOT EXISTS context_messages (
 );
 """
 
+
 def initialize_postgres():
     """Initialize the PostgreSQL database by creating the necessary tables."""
+
+    try:
+        import psycopg2
+
+    except ImportError:
+        raise ImportError("Please install psycopg2 library to use PostgreSQL.")
+
     conn = psycopg2.connect(
         dbname=os.getenv("POSTGRES_DB", "postgres"),
         user=os.getenv("POSTGRES_USER", "postgres"),
         password=os.getenv("POSTGRES_PASSWORD", "postgres"),
         host=os.getenv("POSTGRES_HOST", "localhost"),
-        port=os.getenv("POSTGRES_PORT", "5432")
+        port=os.getenv("POSTGRES_PORT", "5432"),
     )
     cursor = conn.cursor()
 
@@ -69,6 +76,7 @@ def initialize_postgres():
     finally:
         cursor.close()
         conn.close()
+
 
 if __name__ == "__main__":
     initialize_postgres()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,4 +17,4 @@ replicate==1.0.1
 yt-dlp==2024.10.7
 videodb==0.2.10
 slack_sdk==3.33.2
-psycopg2-binary==2.9.10
+


### PR DESCRIPTION
Move psycopg2 imports to runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for database initialization. Users will now see clearer guidance if required components for database connectivity are missing, reducing unexpected runtime issues.
  
- **Chores**
  - Refined dependency management by removing an outdated library reference to streamline the project setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->