### PR TITLE
feat: add url to the returned audio object

### DIFF
--- a/backend/director/tools/videodb_tool.py
+++ b/backend/director/tools/videodb_tool.py
@@ -151,6 +151,7 @@ class VideoDBTool:
             "name": audio.name,
             "collection_id": audio.collection_id,
             "length": audio.length,
+            "url": audio.generate_url()
         }
 
     def generate_image_url(self, image_id):


### PR DESCRIPTION
- added the `url` property to the returned audio object from the `videodb-tool.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced audio functionality: Users now benefit from direct access to audio content via an included URL in audio information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->