### PR TITLE
fix editing agent to use default llm

### DIFF
--- a/backend/director/agents/editing.py
+++ b/backend/director/agents/editing.py
@@ -10,7 +10,7 @@ from director.core.session import (
     RoleTypes,
 )
 from director.tools.videodb_tool import VideoDBTool
-from director.llm.videodb_proxy import VideoDBProxy
+from director.llm import get_default_llm
 
 from videodb.asset import VideoAsset, AudioAsset, ImageAsset, TextAsset
 
@@ -151,7 +151,7 @@ class EditingAgent(BaseAgent):
         self.editing_response = None
 
         # TODO: benchmark different llm
-        self.llm = VideoDBProxy()
+        self.llm = get_default_llm()
 
         # TODO: find a way to get the tool description from function/tool and not hardcode here
         self.tools = [


### PR DESCRIPTION
This PR changes Editing agent to use default llm using `get_default_llm()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the editing tool to use the system’s default language model for AI integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->