### PR TITLE
fix: show media type in agent response

### DIFF
--- a/backend/director/agents/upload.py
+++ b/backend/director/agents/upload.py
@@ -143,7 +143,7 @@ class UploadAgent(BaseAgent):
                 logger.exception(f"Error in uploading {media['title']}: {e}")
         return AgentResponse(
             status=AgentStatus.SUCCESS,
-            message="All the videos in the playlist uploaded successfully as {media_type}",
+            message=f"All the videos in the playlist uploaded successfully as {media_type}",
         )
 
     def run(


### PR DESCRIPTION
# PR Summary
This small PR evaluates the media type in order to be displayed in the agent response message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a message formatting issue to display the correct media type in upload responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->