### PR TITLE
feat: fix editing agent text asset

### DIFF
--- a/backend/director/agents/editing.py
+++ b/backend/director/agents/editing.py
@@ -286,6 +286,8 @@ class EditingAgent(BaseAgent):
                     style = TextStyle(**style_dict)
                     asset_config["style"] = style
 
+                if not asset_config.get("duration"):
+                    asset_config["duration"] = 5
                 text_asset = TextAsset(**asset_config)
                 overlay_at = overlay_asset.get("overlay_at", 0)
                 timeline.add_overlay(overlay_at, text_asset)

--- a/backend/director/agents/editing.py
+++ b/backend/director/agents/editing.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from videodb import TextStyle
 from director.agents.base import BaseAgent, AgentResponse, AgentStatus

--- a/backend/director/agents/editing.py
+++ b/backend/director/agents/editing.py
@@ -89,7 +89,7 @@ In your final output, create a JSON object containing two lists: 'inline_assets'
                text : (string) the text to display
           - Optional:
                duration: (number) how long the text stays visible (seconds)
-               style: (object) e.g. { "fontsize": 24, "fontcolor": "white", "alpha": 0.8, "x": 100, "y": 50 } // "x" and "y" are the position of the text on the screen
+               style: (object) e.g. { "fontsize": 18, "fontcolor": "white", "alpha": 0.7, "boxcolor": "black", "x": 50, "y": 50 } // "x" and "y" are the position of the text on the screen
         - These parameter as Asset's configuration 
 
 3. Final Editing 


### PR DESCRIPTION
## Problem
- The `editing` agent depends upon LLM tool call to fetch the overlay assets
- In one of the overlay assets, `TextAsset` the `style` property takes a specific `TextStyle` property which is it's own separate dataclass
- The LLM response used to give a incompatible dict which causes any editing use case to fail

## Solution
- Change the system prompt to give correct keys in the `style` dict
- Utilise the `TextAsset` for handling styles in the `TextAsset`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of image and text overlay assets to ensure correct processing and display.
	- Clarified the usage of style parameters for text overlays, including more descriptive key names and position coordinates.
- **Style**
	- Updated example prompts for text asset styles to enhance clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->