### PR TITLE
deps: upgrade `openai-function-calling` version

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ Flask-Cors==4.0.1
 openai==1.55.3
 PyJWT==2.10.0
 Pillow==11.0.0
-openai-function-calling==2.4.0
+openai-function-calling==2.6.0
 pydantic==2.8.2
 pydantic-settings==2.4.0
 python-dotenv==1.0.1


### PR DESCRIPTION
## Problem
The current `requirements.txt` has `openai-function-calling` dependency with version `2.4.0` which does not work for python versions greater than `3.13`. Hence the setup fails of version higher than `3.13`

## Solution
The updated version of the package has compatibility with higher versions of python with no upper limit for python version
Upgrading the package to that version solves the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the OpenAI package to a newer version for improved compatibility and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->