### PR TITLE
Ankit/fix vite

### DIFF
--- a/docs/get_started/railway.md
+++ b/docs/get_started/railway.md
@@ -60,7 +60,6 @@
 * After deployment, go to the [Railway project dashboard](https://railway.app/dashboard), and under the backend service, update the environment variables:
     ``` 
     VIDEO_DB_API_KEY="your_video_db_api_key"
-    OPENAI_API_KEY="your_openai_api_key"
     ```
 
 * Go to Settings → Networking → Public Networking, generate a domain, and copy the domain. You will need to use this domain in the frontend service configuration.

--- a/docs/get_started/render.md
+++ b/docs/get_started/render.md
@@ -11,7 +11,6 @@
 After deployment, update the backend environment variables:
     ``` 
     VIDEO_DB_API_KEY="your_video_db_api_key"
-    OPENAI_API_KEY="your_openai_api_key"
     ```
 
 ### Frontend Configuration

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /app
 COPY . /app/
 
 RUN npm install
-RUN npm run build
 
 EXPOSE 8080
-CMD ["npm", "run", "preview"]
+CMD ["npm", "run", "dev"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY . /app/
 
 RUN npm install
+RUN npm run build
 
 EXPOSE 8080
-CMD ["npm", "run", "dev"]
+CMD ["npm", "run", "preview"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,6 @@
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.41",
     "tailwindcss": "^3.4.10",
-    "vite": "^5.4.1"
+    "vite": "5.4.1"
   }
 }


### PR DESCRIPTION
Pin vite.js -v to `5.4.1` and remove optional `OPENAI_API_KEY` from deployment docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated deployment instructions for Railway and Render by removing references to a specific environment variable.
- **Chores**
  - Restricted the development dependency for a build tool to an exact version for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->