### PR TITLE
feat: remove model name support

### DIFF
--- a/backend/director/agents/index.py
+++ b/backend/director/agents/index.py
@@ -51,12 +51,6 @@ INDEX_AGENT_PARAMETERS = {
                     "default": "shot",
                     "description": "Method to use for scene detection and frame extraction",
                 },
-                "model_name": {
-                    "type": "string",
-                    "description": "The name of the model to use for scene detection and frame extraction",
-                    "default": "gpt4-o",
-                    "enum": ["gemini-1.5-flash", "gemini-1.5-pro", "gpt4-o"],
-                },
                 "shot_based_config": {
                     "type": "object",
                     "description": "Configuration for shot-based scene detection and frame extraction, This is a required parameter for shot_based indexing",
@@ -252,9 +246,6 @@ class IndexAgent(BaseAgent):
 
             elif index_type == "scene":
                 scene_index_type = scene_index_config["type"]
-                scene_index_model_name = scene_index_config.get(
-                    "model_name", "gpt4-o"
-                )
                 scene_index_config = scene_index_config[
                     scene_index_type + "_based_config"
                 ]
@@ -263,7 +254,6 @@ class IndexAgent(BaseAgent):
                     extraction_type=scene_index_type,
                     extraction_config=scene_index_config,
                     prompt=scene_index_prompt,
-                    model_name=scene_index_model_name,
                 )
                 self.videodb_tool.get_scene_index(
                     video_id=video_id, scene_id=scene_index_id

--- a/backend/director/tools/videodb_tool.py
+++ b/backend/director/tools/videodb_tool.py
@@ -9,6 +9,7 @@ from videodb.asset import VideoAsset, ImageAsset
 from director.tools.elevenlabs import VOICE_ID_MAP
 from director.constants import DOWNLOADS_PATH
 
+
 class VideoDBTool:
     def __init__(self, collection_id="default"):
         self.conn = videodb.connect(
@@ -268,7 +269,6 @@ class VideoDBTool:
         video_id: str,
         extraction_type=SceneExtractionType.shot_based,
         extraction_config={},
-        model_name=None,
         prompt=None,
     ):
         video = self.collection.get_video(video_id)
@@ -276,7 +276,6 @@ class VideoDBTool:
             extraction_type=extraction_type,
             extraction_config=extraction_config,
             prompt=prompt,
-            model_name=model_name,
         )
 
     def list_scene_index(self, video_id: str):
@@ -424,6 +423,7 @@ class VideoDBTool:
             "stream_url": video.generate_stream(),
             "length": video.length,
         }
+
     def delete_audio(self, audio_id):
         """Delete a specific audio by its ID."""
         if not audio_id:
@@ -478,6 +478,7 @@ class VideoDBTool:
                 "An unexpected error occurred while deleting the video. Please try again later."
             )
 
+
 class VDBVideoGenerationTool:
     def __init__(self, collection_id="default"):
         self.videodb_tool = VideoDBTool(collection_id=collection_id)
@@ -489,34 +490,37 @@ class VDBVideoGenerationTool:
         response = requests.get(video_url, stream=True)
         response.raise_for_status()
 
-        if not response.headers.get('Content-Type', '').startswith('video'):
+        if not response.headers.get("Content-Type", "").startswith("video"):
             raise ValueError(f"The URL does not point to a video file: {video_url}")
 
-        with open(save_at, 'wb') as file:
+        with open(save_at, "wb") as file:
             file.write(response.content)
 
-    def text_to_video(self, prompt: str, save_at: str, duration: float, config: dict = {}):
+    def text_to_video(
+        self, prompt: str, save_at: str, duration: float, config: dict = {}
+    ):
         media = self.collection.generate_video(prompt=prompt, duration=duration)
-        
+
         download_response = self.videodb_tool.download(media.stream_url)
         download_url = download_response.get("download_url")
 
         self._download_video_file(download_url, save_at)
         if not os.path.exists(save_at):
             raise Exception(f"Failed to save video at {save_at}")
-        
+
         video_dict = {
-                "id": media.id,
-                "collection_id": media.collection_id,
-                "stream_url": media.stream_url,
-                "player_url": media.player_url,
-                "name": media.name,
-                "description": media.description,
-                "thumbnail_url": media.thumbnail_url,
-                "length": media.length,
-            }
+            "id": media.id,
+            "collection_id": media.collection_id,
+            "stream_url": media.stream_url,
+            "player_url": media.player_url,
+            "name": media.name,
+            "description": media.description,
+            "thumbnail_url": media.thumbnail_url,
+            "length": media.length,
+        }
         return video_dict
-        
+
+
 class VDBAudioGenerationTool:
     def __init__(self, collection_id="default"):
         self.videodb_tool = VideoDBTool(collection_id=collection_id)
@@ -527,51 +531,55 @@ class VDBAudioGenerationTool:
         response = requests.get(audio_url, stream=True)
         response.raise_for_status()
 
-        with open(save_at, 'wb') as file:
+        with open(save_at, "wb") as file:
             file.write(response.content)
-
 
     def generate_sound_effect(
         self, prompt: str, save_at: str, duration: float, config: dict
-    ):        
-        audio = self.collection.generate_sound_effect(prompt=prompt, duration=duration, config=config)
+    ):
+        audio = self.collection.generate_sound_effect(
+            prompt=prompt, duration=duration, config=config
+        )
 
         download_url = audio.generate_url()
         self._download_audio_file(download_url, save_at)
-        
+
         return {
             "id": audio.id,
             "collection_id": audio.collection_id,
             "name": audio.name,
             "length": audio.length,
-            "url": audio.generate_url()
+            "url": audio.generate_url(),
         }
-        
+
     def text_to_speech(self, text: str, save_at: str, config: dict):
-        audio = self.collection.generate_voice(text=text, voice_name=VOICE_ID_MAP.get(config.get("voice_id")), config=config)
+        audio = self.collection.generate_voice(
+            text=text,
+            voice_name=VOICE_ID_MAP.get(config.get("voice_id")),
+            config=config,
+        )
 
         download_url = audio.generate_url()
         self._download_audio_file(download_url, save_at)
-        
+
         return {
             "id": audio.id,
             "collection_id": audio.collection_id,
             "name": audio.name,
             "length": audio.length,
-            "url": audio.generate_url()
+            "url": audio.generate_url(),
         }
-    
-    def generate_music(self, prompt: str, save_at:str, duration:float):
+
+    def generate_music(self, prompt: str, save_at: str, duration: float):
         audio = self.collection.generate_music(prompt=prompt, duration=duration)
 
         download_url = audio.generate_url()
         self._download_audio_file(download_url, save_at)
-        
+
         return {
             "id": audio.id,
             "collection_id": audio.collection_id,
             "name": audio.name,
             "length": audio.length,
-            "url": audio.generate_url()
+            "url": audio.generate_url(),
         }
-


### PR DESCRIPTION
This PR fixes the #176 issue

## Reason
The VideoDB SDK's `model_name` parameter for the `index_scenes` feature does not support the given model names.

## Solution
Removed the support for the parameters till the `model_name` are finalised

---
<img width="1351" alt="Screenshot 2025-06-10 at 12 12 51 PM" src="https://github.com/user-attachments/assets/d191cabd-f7dd-4b0a-ab5e-a26e3bff6a5b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the "model_name" option from scene indexing configuration and related logic.
  - Updated method signatures and configuration options to reflect the removal of "model_name".
  - Improved code consistency and readability with standardized formatting and style adjustments.

- **Style**
  - Standardized string formatting and indentation for better code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->