### PR TITLE
fix: removed redundant arg

### DIFF
--- a/backend/director/handler.py
+++ b/backend/director/handler.py
@@ -70,7 +70,7 @@ class ChatHandler:
             CodeAssistantAgent,
             WebSearchAgent,
             VoiceReplacementAgent,
-            PricingAgent
+            PricingAgent,
         ]
 
     def add_videodb_state(self, session):
@@ -148,7 +148,7 @@ class VideoDBHandler:
     def upload(self, source, source_type="url", media_type="video", name=None):
         return self.videodb_tool.upload(source, source_type, media_type, name)
 
-    def get_collection(self, collection_id):
+    def get_collection(self):
         """Get a collection by ID."""
         return self.videodb_tool.get_collection()
 
@@ -213,7 +213,7 @@ class ConfigHandler:
         """Check the configuration of the server."""
         videodb_configured = True if os.getenv("VIDEO_DB_API_KEY") else False
 
-        db = load_db(os.getenv("SERVER_DB_TYPE",  os.getenv("DB_TYPE", "sqlite")))
+        db = load_db(os.getenv("SERVER_DB_TYPE", os.getenv("DB_TYPE", "sqlite")))
         db_configured = db.health_check()
         return {
             "videodb_configured": videodb_configured,


### PR DESCRIPTION
the `videodb/collection/<collection_id>` calls the `VideoDBHandler.get_collection` method

```
 if collection_id:
        return videodb.get_collection()
```

But the handler took a `collection_id` argument, which was redundant, but also caused the API to fail, but to arg mismatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated method to remove an unused parameter for improved clarity.
  - Made minor formatting adjustments for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->