### PR TITLE
feat: sorting messages by `created_at`

### DIFF
--- a/backend/director/db/postgres/db.py
+++ b/backend/director/db/postgres/db.py
@@ -131,7 +131,8 @@ class PostgresDB(BaseDB):
 
     def get_conversations(self, session_id: str) -> list:
         self.cursor.execute(
-            "SELECT * FROM conversations WHERE session_id = %s", (session_id,)
+            "SELECT * FROM conversations WHERE session_id = %s ORDER BY created_at ASC",
+            (session_id,),
         )
         rows = self.cursor.fetchall()
         conversations = []
@@ -143,7 +144,7 @@ class PostgresDB(BaseDB):
 
     def get_context_messages(self, session_id: str) -> list:
         self.cursor.execute(
-            "SELECT context_data FROM context_messages WHERE session_id = %s",
+            "SELECT context_data FROM context_messages WHERE session_id = %s ORDER BY created_at ASC",
             (session_id,),
         )
         result = self.cursor.fetchone()

--- a/backend/director/db/postgres/db.py
+++ b/backend/director/db/postgres/db.py
@@ -144,7 +144,7 @@ class PostgresDB(BaseDB):
 
     def get_context_messages(self, session_id: str) -> list:
         self.cursor.execute(
-            "SELECT context_data FROM context_messages WHERE session_id = %s ORDER BY created_at ASC",
+            "SELECT context_data FROM context_messages WHERE session_id = %s",
             (session_id,),
         )
         result = self.cursor.fetchone()

--- a/backend/director/db/sqlite/db.py
+++ b/backend/director/db/sqlite/db.py
@@ -153,7 +153,8 @@ class SQLiteDB(BaseDB):
 
     def get_conversations(self, session_id: str) -> list:
         self.cursor.execute(
-            "SELECT * FROM conversations WHERE session_id = ?", (session_id,)
+            "SELECT * FROM conversations WHERE session_id = ? ORDER BY created_at ASC",
+            (session_id,),
         )
         rows = self.cursor.fetchall()
         conversations = []
@@ -175,7 +176,7 @@ class SQLiteDB(BaseDB):
         :rtype: list
         """
         self.cursor.execute(
-            "SELECT context_data FROM context_messages WHERE session_id = ?",
+            "SELECT context_data FROM context_messages WHERE session_id = ? ORDER BY created_at ASC",
             (session_id,),
         )
         result = self.cursor.fetchone()

--- a/backend/director/db/sqlite/db.py
+++ b/backend/director/db/sqlite/db.py
@@ -176,7 +176,7 @@ class SQLiteDB(BaseDB):
         :rtype: list
         """
         self.cursor.execute(
-            "SELECT context_data FROM context_messages WHERE session_id = ? ORDER BY created_at ASC",
+            "SELECT context_data FROM context_messages WHERE session_id = ?",
             (session_id,),
         )
         result = self.cursor.fetchone()


### PR DESCRIPTION
- The messages when sent to the user, are not sorting by date. This causes the messages to sometimes be out of order.

Example:

![Screenshot 2025-06-20 at 12 55 24 PM](https://github.com/user-attachments/assets/ad463563-01c7-42c1-a44f-19e3e010ea86)

This PR enforces the DB to sort them by the `created_at` time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured conversations are consistently displayed in chronological order based on their creation time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->