### PR TITLE
feat: upload name media type args

### DIFF
--- a/backend/director/entrypoint/api/routes.py
+++ b/backend/director/entrypoint/api/routes.py
@@ -247,9 +247,12 @@ def upload_video(collection_id):
                 name=file_name,
             )
         elif "source" in request.json:
-            source = request.json["source"]
-            source_type = request.json["source_type"]
-            return videodb.upload(source=source, source_type=source_type)
+            return videodb.upload(
+                source=request.json["source"],
+                source_type=request.json.get("source_type", "url"),
+                media_type=request.json.get("media_type", "video"),
+                name=request.json.get("name", None),
+            )
         else:
             return {"message": "No valid source provided"}, 400
     except Exception as e:


### PR DESCRIPTION
- upload url can take in `name` and `media_type` args for client-side presigned url upload handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional "media_type" and "name" parameters when uploading videos.
  * Improved flexibility by providing a default value for "source_type" if it is not specified during video upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->