### PR TITLE
feat: rename and share session handling

### DIFF
--- a/backend/director/constants.py
+++ b/backend/director/constants.py
@@ -31,3 +31,41 @@ class EnvPrefix(str, Enum):
     GOOGLEAI_ = "GOOGLEAI_"
 
 DOWNLOADS_PATH="director/downloads"
+
+CHAT_NAMING_SYSTEM_PROMPT = """
+You are an assistant that generates short, descriptive titles for chat conversations.
+The title should summarize the main intent or topic of the user's first message.
+
+Guidelines:
+
+**Output you give should strictly just be the title without any markdown content in plain text**
+
+Keep the title under 6 words.
+
+Use concise, professional phrasing.
+
+Don't include punctuation unless necessary.
+
+Capitalize like a headline (e.g., “Check SQL Query Logic”).
+
+Avoid emojis or filler words.
+
+Example input and outputs:
+
+“Can you give me download links for these videos?” → Generate Video Download Links
+
+“Summarize the lecture video for me” → Lecture Video Summary
+
+“Add a watermark to my demo” → Add Watermark to Video
+
+“Trim the video from 2:10 to 3:45” → Trim Video Segment
+
+“Combine these three clips into one” → Merge Video Clips
+
+“Extract subtitles from this recording” → Extract Video Subtitles
+
+“Translate this video into Spanish” → Translate Video to Spanish
+
+“Generate a short trailer from the full video” → Create Video Trailer
+
+"""

--- a/backend/director/core/session.py
+++ b/backend/director/core/session.py
@@ -393,6 +393,10 @@ class Session:
         """Delete the session from the database."""
         return self.db.delete_session(self.session_id)
 
+    def update(self, **kwargs):
+        """Update the session in the database."""
+        return self.db.update_session(self.session_id, **kwargs)
+
     def emit_event(self, event: BaseEvent, namespace="/chat"):
         """Emits a structured WebSocket event to notify all clients about updates."""
 

--- a/backend/director/core/session.py
+++ b/backend/director/core/session.py
@@ -220,28 +220,31 @@ class OutputMessage(BaseMessage):
     status: MsgStatus = MsgStatus.progress
 
     def update_status(self, status: MsgStatus):
-        """Update the status of the message and publish the message to the socket. for loading state."""
+        """Update the status and broadcast to session room."""
         self.status = status
         self._publish()
 
     def push_update(self):
-        """Publish the message to the socket."""
+        """Push real-time update to session room."""
         try:
             self._publish()
         except Exception as e:
-            print(f"Error in emitting message: {str(e)}")
+            print(f"Error in emitting update to session {self.session_id}: {str(e)}")
 
     def publish(self):
-        """Store the message in the database. for conversation history and publish the message to the socket."""
+        """Store in database and broadcast final result to session room."""
         self._publish()
 
     def _publish(self):
         try:
-            emit("chat", self.model_dump(), namespace="/chat")
+            emit("chat", self.model_dump(), 
+                 room=self.session_id, 
+                 namespace="/chat")
+            print(f"Emitted message to session room: {self.session_id}")
         except Exception as e:
-            print(f"Error in emitting message: {str(e)}")
-        self.db.add_or_update_msg_to_conv(**self.model_dump())
+            print(f"Error emitting to session {self.session_id}: {str(e)}")
 
+        self.db.add_or_update_msg_to_conv(**self.model_dump())
 
 def format_user_message(message: dict) -> dict:
     message_content = message.get("content")

--- a/backend/director/core/session.py
+++ b/backend/director/core/session.py
@@ -393,7 +393,7 @@ class Session:
         """Delete the session from the database."""
         return self.db.delete_session(self.session_id)
 
-    def update(self, **kwargs):
+    def update(self, **kwargs) -> bool:
         """Update the session in the database."""
         return self.db.update_session(self.session_id, **kwargs)
 

--- a/backend/director/db/base.py
+++ b/backend/director/db/base.py
@@ -49,8 +49,10 @@ class BaseDB(ABC):
         pass
 
     @abstractmethod
-    def delete_session(self, session_id: str) -> bool:
-        """Delete a session from the database."""
+    def delete_session(self, session_id: str) -> tuple[bool, list]:
+        """Delete a session from the database.
+        :return: (success, failed_components)
+        """
         pass
 
     @abstractmethod

--- a/backend/director/db/base.py
+++ b/backend/director/db/base.py
@@ -44,6 +44,26 @@ class BaseDB(ABC):
         pass
 
     @abstractmethod
+    def update_session(self, session_id: str, **kwargs) -> bool:
+        """Update a session in the database."""
+        pass
+
+    @abstractmethod
+    def delete_session(self, session_id: str) -> bool:
+        """Delete a session from the database."""
+        pass
+
+    @abstractmethod
+    def make_session_public(self, session_id: str, is_public: bool) -> bool:
+        """Make a session public or private."""
+        pass
+
+    @abstractmethod
+    def get_public_session(self, session_id: str) -> dict:
+        """Get a public session by session_id."""
+        pass
+
+    @abstractmethod
     def health_check(self) -> bool:
         """Check if the database is healthy."""
         pass

--- a/backend/director/db/postgres/initialize.py
+++ b/backend/director/db/postgres/initialize.py
@@ -70,10 +70,9 @@ def initialize_postgres():
         cursor.execute(CREATE_SESSIONS_TABLE)
         cursor.execute(CREATE_CONVERSATIONS_TABLE)
         cursor.execute(CREATE_CONTEXT_MESSAGES_TABLE)
-        conn.commit()
-
         cursor.execute("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS name TEXT")
         cursor.execute("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS is_public BOOLEAN DEFAULT FALSE")
+        conn.commit()
         logger.info("PostgreSQL tables created successfully")
     except Exception as e:
         logger.exception(f"Error creating PostgreSQL tables: {e}")

--- a/backend/director/db/postgres/initialize.py
+++ b/backend/director/db/postgres/initialize.py
@@ -11,6 +11,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     session_id TEXT PRIMARY KEY,
     video_id TEXT,
     collection_id TEXT,
+    name TEXT,
+    is_public BOOLEAN DEFAULT FALSE,
     created_at BIGINT,
     updated_at BIGINT,
     metadata JSONB
@@ -69,6 +71,9 @@ def initialize_postgres():
         cursor.execute(CREATE_CONVERSATIONS_TABLE)
         cursor.execute(CREATE_CONTEXT_MESSAGES_TABLE)
         conn.commit()
+
+        cursor.execute("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS name TEXT")
+        cursor.execute("ALTER TABLE sessions ADD COLUMN IF NOT EXISTS is_public BOOLEAN DEFAULT FALSE")
         logger.info("PostgreSQL tables created successfully")
     except Exception as e:
         logger.exception(f"Error creating PostgreSQL tables: {e}")

--- a/backend/director/db/sqlite/initialize.py
+++ b/backend/director/db/sqlite/initialize.py
@@ -7,6 +7,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     session_id TEXT PRIMARY KEY,
     video_id TEXT,
     collection_id TEXT,
+    name TEXT,
+    is_public BOOLEAN DEFAULT FALSE,
     created_at INTEGER,
     updated_at INTEGER,
     metadata JSON
@@ -49,9 +51,19 @@ def initialize_sqlite(db_name="director.db"):
     conn = sqlite3.connect(db_name)
     cursor = conn.cursor()
 
+    # Create base tables
     cursor.execute(CREATE_SESSIONS_TABLE)
     cursor.execute(CREATE_CONVERSATIONS_TABLE)
     cursor.execute(CREATE_CONTEXT_MESSAGES_TABLE)
+
+    cursor.execute("PRAGMA table_info(sessions)")
+    columns = [col[1] for col in cursor.fetchall()]
+
+    if "name" not in columns:
+        cursor.execute("ALTER TABLE sessions ADD COLUMN name TEXT")
+
+    if "is_public" not in columns:
+        cursor.execute("ALTER TABLE sessions ADD COLUMN is_public BOOLEAN DEFAULT FALSE")
 
     conn.commit()
     conn.close()

--- a/backend/director/entrypoint/api/routes.py
+++ b/backend/director/entrypoint/api/routes.py
@@ -62,15 +62,12 @@ def get_session(session_id):
             }, 500
     elif request.method == "POST":
         data = request.get_json()
-        print(data)
-        session_handler.create_session(
+        
+        session = session_handler.create_session(
             data.get("message")
         )
-        return {
-            "session_id": data.get("session_id"),
-            "created_at": data.get("created_at"),
-            "name": "New Session!"
-        }, 200
+
+        return session, 200
 
 
 @session_bp.route("/<session_id>/rename", methods=["PUT"])

--- a/backend/director/entrypoint/api/routes.py
+++ b/backend/director/entrypoint/api/routes.py
@@ -35,7 +35,7 @@ def get_sessions():
     return session_handler.get_sessions()
 
 
-@session_bp.route("/<session_id>", methods=["GET", "DELETE"])
+@session_bp.route("/<session_id>", methods=["GET", "DELETE", "POST"])
 def get_session(session_id):
     """
     Get or delete the session details
@@ -60,6 +60,17 @@ def get_session(session_id):
             return {
                 "message": f"Failed to delete the entry for following components: {', '.join(failed_components)}"
             }, 500
+    elif request.method == "POST":
+        data = request.get_json()
+        print(data)
+        session_handler.create_session(
+            data.get("message")
+        )
+        return {
+            "session_id": data.get("session_id"),
+            "created_at": data.get("created_at"),
+            "name": "New Session!"
+        }, 200
 
 
 @session_bp.route("/<session_id>/rename", methods=["PUT"])

--- a/backend/director/entrypoint/api/socket_io.py
+++ b/backend/director/entrypoint/api/socket_io.py
@@ -1,18 +1,40 @@
 import os
 
 from flask import current_app as app
-from flask_socketio import Namespace
-
+from flask_socketio import Namespace, join_room, emit
 from director.db import load_db
 from director.handler import ChatHandler
 
-
 class ChatNamespace(Namespace):
-    """Chat namespace for socket.io"""
-
+    """Chat namespace for socket.io with session-based rooms"""
+    
+    def on_connect(self):
+        """Handle client connection"""
+        print(f"Client connected to chat namespace")
+    
     def on_chat(self, message):
-        """Handle chat messages"""
+        """Handle chat messages and auto-join session room"""
+        session_id = message.get('session_id')
+        if not session_id:
+            emit('error', {'message': 'session_id is required'})
+            return
+            
+        join_room(session_id)
+        print(f"Client joined session room {session_id}")
+        
         chat_handler = ChatHandler(
             db=load_db(os.getenv("SERVER_DB_TYPE", app.config["DB_TYPE"]))
         )
         chat_handler.chat(message)
+    
+    def on_join_session(self, data):
+        """Explicitly join a session room (for reconnection)"""
+        session_id = data.get('session_id')
+        if session_id:
+            join_room(session_id)
+            emit('session_joined', {'session_id': session_id})
+            print(f"Client explicitly joined session room {session_id}")
+    
+    def on_disconnect(self):
+        """Handle client disconnection"""
+        print(f"Client disconnected from chat namespace")

--- a/backend/director/handler.py
+++ b/backend/director/handler.py
@@ -140,6 +140,16 @@ class SessionHandler:
         session = Session(db=self.db, session_id=session_id)
         return session.delete()
 
+    def rename_session(self, session_id, new_name):
+        """Rename a session by updating its name field."""
+        session = Session(db=self.db, session_id=session_id)
+        success = session.update(name=new_name)
+        if success:
+            return {"message": "Session renamed successfully", "session_id": session_id, "name": new_name}
+        else:
+            return {"message": "Failed to rename session"}, 500
+
+
 
 class VideoDBHandler:
     def __init__(self, collection_id="default"):

--- a/backend/director/handler.py
+++ b/backend/director/handler.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from typing import Optional
 
 from director.agents.frame import FrameAgent
 from director.agents.summarize_video import SummarizeVideoAgent
@@ -149,6 +150,9 @@ class SessionHandler:
         else:
             return {"message": "Failed to rename session"}, 500
 
+    def create_session(self, message):
+        session = Session(db=self.db, **message)
+        session.create()
 
 
 class VideoDBHandler:

--- a/backend/director/handler.py
+++ b/backend/director/handler.py
@@ -1,6 +1,11 @@
+import json
 import os
 import logging
 from typing import Optional
+
+from director.constants import CHAT_NAMING_SYSTEM_PROMPT
+from director.llm import get_default_llm
+from director.llm.base import LLMResponseStatus
 
 from director.agents.frame import FrameAgent
 from director.agents.summarize_video import SummarizeVideoAgent
@@ -29,7 +34,7 @@ from director.agents.clone_voice import CloneVoiceAgent
 from director.agents.voice_replacement import VoiceReplacementAgent
 
 
-from director.core.session import Session, InputMessage, MsgStatus
+from director.core.session import ContextMessage, RoleTypes, Session, InputMessage, MsgStatus
 from director.core.reasoning import ReasoningEngine
 from director.db.base import BaseDB
 from director.db import load_db
@@ -153,6 +158,33 @@ class SessionHandler:
     def create_session(self, message):
         session = Session(db=self.db, **message)
         session.create()
+
+        session_dict = session.get()
+        if not session_dict["name"]:
+            llm = get_default_llm()
+            context_messages = [
+                ContextMessage(
+                    role=RoleTypes.system,
+                    content=CHAT_NAMING_SYSTEM_PROMPT
+                ),
+                ContextMessage(
+                    role=RoleTypes.user,
+                    content=json.dumps(session_dict["conversation"]) if session_dict["conversation"] is not None else message.get("content", json.dumps(message, indent=4))
+                )
+            ]
+
+            response = llm.chat_completions(
+                messages=[msg.to_llm_msg() for msg in context_messages]
+            )
+            if response.status == LLMResponseStatus.SUCCESS:
+                name = response.content
+                self.rename_session(
+                    session_id=session.session_id,
+                    new_name=name
+                )
+        
+        return session.get()
+
 
 
 class VideoDBHandler:

--- a/frontend/src/hooks/shareViewHandler.js
+++ b/frontend/src/hooks/shareViewHandler.js
@@ -1,0 +1,183 @@
+import { computed, onBeforeMount, reactive, ref, toRefs, watch } from "vue";
+
+const fetchData = async (rootUrl, endpoint) => {
+  const res = {};
+  res.status = "success";
+  res.data = {};
+  return res;
+};
+
+export function publicUseVideoDBAgent(config, sessionId) {
+  const { debug = false, socketUrl, httpUrl } = config;
+  if (debug) console.log("debug :videodb-chat config", config);
+
+  const session = reactive({
+    isConnected: true,
+    sessionId,
+    videoId: null,
+    collectionId: "default",
+  });
+
+  const configStatus = ref(null);
+
+  const collections = ref([]);
+  const sessions = ref([]);
+  const sessionsSorted = computed(() => {
+    return [...sessions.value].sort((a, b) => b.created_at - a.created_at);
+  });
+  const agents = ref([]);
+
+  const conversations = reactive({});
+  const activeCollectionData = ref(null);
+
+  const activeCollectionVideos = ref(null);
+  const activeVideoData = ref(null);
+
+  const activeCollectionAudios = ref(null);
+  const activeAudioData = ref(null);
+
+  const activeCollectionImages = ref(null);
+  const activeImageData = ref(null);
+
+  fetch(`${httpUrl}/session/public/${sessionId}`)
+    .then((res) => res.json())
+    .then((res) => {
+      console.log("debug :videodb-chat res", res);
+      if (res) {
+        session.videoId = res.video_id || null;
+        session.collectionId =
+          res.collection_id || session.collectionId || null;
+
+        // Clear existing conversations
+        Object.keys(conversations).forEach((key) => delete conversations[key]);
+
+        // Populate conversations with fetched data
+        if (res.conversation) {
+          res.conversation.forEach((message) => {
+            const { conv_id, msg_id } = message;
+            if (!conversations[conv_id]) {
+              conversations[conv_id] = {};
+            }
+            conversations[String(conv_id)][String(msg_id)] = {
+              sender: message.msg_type === "input" ? "user" : "assistant",
+              ...message,
+            };
+          });
+        }
+      }
+    })
+    .catch((error) => {
+      if (debug) console.error("Error fetching public session:", error);
+    });
+  const fetchConfigStatus = async () => {
+    try {
+      const res = await fetchData(httpUrl, "/config/check");
+      return res;
+    } catch (error) {
+      if (debug) console.error("Error fetching config status:", error);
+      return { data: { backend: false } };
+    }
+  };
+
+  const uploadMedia = async (uploadData) => {};
+
+  const generateAudioUrl = async (collectionId, audioId) => {
+    const res = {};
+    res.status = "success";
+    res.url = "";
+    return res;
+  };
+
+  const generateImageUrl = async (collectionId, imageId) => {
+    const res = {};
+    res.status = "success";
+    res.url = "";
+    return res;
+  };
+
+  const saveMeetingContext = async (msgId, context) => {
+    const res = {};
+    res.status = "success";
+    res.data = {};
+    return res;
+  };
+
+  const makeSessionPublic = async (sessionId, isPublic = true) => {
+    const res = {};
+    res.status = "success";
+    res.data = {};
+    return res;
+  };
+
+  const fetchMeetingContext = async (uiId) => {
+    const res = {};
+    res.status = "success";
+    res.data = {};
+    return res;
+  };
+
+  const refetchCollectionVideos = async () => {};
+
+  const refetchCollectionAudios = async () => {};
+
+  const refetchCollectionImages = async () => {};
+
+  onBeforeMount(() => {
+    fetchConfigStatus().then((res) => {
+      if (debug) console.log("debug :videodb-chat config status", res);
+      configStatus.value = res.data;
+    });
+  });
+
+  const loadSession = (sessionId) => {};
+
+  const deleteSession = (sessionId) => {};
+
+  const updateCollection = async () => {};
+
+  const createCollection = async (name, description) => {};
+
+  const deleteCollection = async (collectionId) => {};
+
+  const deleteVideo = async (collectionId, videoId) => {};
+
+  const deleteAudio = async (collectionId, audioId) => {};
+
+  const deleteImage = async (collectionId, imageId) => {};
+
+  const addMessage = (message) => {};
+
+  return {
+    ...toRefs(session),
+    configStatus,
+    collections,
+    sessions: sessionsSorted,
+    agents,
+    activeCollectionData,
+    activeCollectionVideos,
+    activeVideoData,
+    refetchCollectionVideos,
+    activeCollectionAudios,
+    activeAudioData,
+    refetchCollectionAudios,
+    activeCollectionImages,
+    activeImageData,
+    refetchCollectionImages,
+    conversations,
+    addMessage,
+    loadSession,
+    deleteSession,
+    updateCollection,
+    createCollection,
+    deleteCollection,
+    deleteVideo,
+    deleteAudio,
+    deleteImage,
+    uploadMedia,
+    generateImageUrl,
+    generateAudioUrl,
+    saveMeetingContext,
+    fetchMeetingContext,
+    makeSessionPublic,
+  };
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,11 +1,17 @@
 import { createRouter, createWebHistory } from "vue-router";
 import DefaultView from "../views/DefaultView.vue";
+import ShareView from "../views/ShareView.vue";
 
 const routes = [
   {
     path: "/",
     name: "Default",
     component: DefaultView,
+  },
+  {
+    path: "/share/:sessionId",
+    name: "Share",
+    component: ShareView,
   },
 ];
 

--- a/frontend/src/views/ShareView.vue
+++ b/frontend/src/views/ShareView.vue
@@ -1,0 +1,39 @@
+<script setup>
+import { useRoute } from "vue-router";
+import { ChatInterface } from "@videodb/chat-vue";
+import "@videodb/chat-vue/dist/style.css";
+
+const route = useRoute();
+const sessionId = route.params.sessionId;
+const BACKEND_URL = import.meta.env.VITE_APP_BACKEND_URL;
+import { publicUseVideoDBAgent } from "../hooks/shareViewHandler";
+const publicHook = (config) => publicUseVideoDBAgent(config, sessionId);
+</script>
+
+<template>
+  <div class="public-share-page">
+    <chat-interface
+      :custom-chat-hook="publicHook"
+      :chat-hook-config="{
+        socketUrl: `${BACKEND_URL}/chat`,
+        httpUrl: `${BACKEND_URL}`,
+        debug: true,
+        sessionId: sessionId,
+      }"
+      :show-sidebar="false"
+      :show-header="false"
+      :show-chat-input="false"
+      :sidebar-config="{ enabled: false }"
+      :default-screen-config="{ enableVideoView: false }"
+      size="full"
+    />
+  </div>
+</template>
+
+<style scoped>
+.public-share-page {
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+}
+</style>


### PR DESCRIPTION
## Features added
- Added `name` column to `sessions` table for renaming sessions
- Added `is_public` column to `sessions` table for allowing session sharing
    - This allows user to have sharable links of their chats if they were to independently host them
- Added DB handlers and routes for making renaming and sharing possible
- UI synced with the `videodb-chat` PR: https://github.com/video-db/videodb-chat/pull/102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Public, read-only share view at /share/:sessionId with a minimal full-viewport chat.
  - Automatic session naming via LLM when creating unnamed sessions.

- **API**
  - POST to create sessions; endpoints to rename sessions, toggle public visibility, and fetch public sessions with conversations.
  - Socket support to join session rooms for targeted real-time updates.

- **Frontend**
  - New public hook to load/display shared sessions and assets.

- **Chores**
  - DB schema/storage extended for session names and public visibility.

- **Bug Fixes**
  - Real-time emissions scoped to session rooms with improved handling and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->