### PR TITLE
Feat/session reconnection

### DIFF
--- a/backend/director/core/session.py
+++ b/backend/director/core/session.py
@@ -208,8 +208,15 @@ class InputMessage(BaseMessage):
     msg_type: MsgType = MsgType.input
 
     def publish(self):
-        """Store the message in the database. for conversation history."""
+        """Store the message in the database and broadcast to session room."""
         self.db.add_or_update_msg_to_conv(**self.model_dump(exclude={"db"}))
+        try:
+            emit("chat", self.model_dump(exclude={"db"}), 
+                 room=self.session_id, 
+                 namespace="/chat")
+            print(f"Broadcasted input message to session room: {self.session_id}")
+        except Exception as e:
+            print(f"Error broadcasting input message to session {self.session_id}: {str(e)}")
 
 
 class OutputMessage(BaseMessage):

--- a/backend/director/entrypoint/api/socket_io.py
+++ b/backend/director/entrypoint/api/socket_io.py
@@ -1,18 +1,40 @@
 import os
 
 from flask import current_app as app
-from flask_socketio import Namespace
-
+from flask_socketio import Namespace, join_room, emit
 from director.db import load_db
 from director.handler import ChatHandler
 
-
 class ChatNamespace(Namespace):
-    """Chat namespace for socket.io"""
-
+    """Chat namespace for socket.io with session-based rooms"""
+    
+    def on_connect(self):
+        """Handle client connection"""
+        print(f"Client connected to chat namespace")
+    
     def on_chat(self, message):
-        """Handle chat messages"""
+        """Handle chat messages and auto-join session room"""
+        session_id = message.get('session_id')
+        if not session_id:
+            emit('error', {'message': 'session_id is required'})
+            return
+            
+        join_room(session_id)
+        print(f"Client joined session room {session_id}")
+        
         chat_handler = ChatHandler(
             db=load_db(os.getenv("SERVER_DB_TYPE", app.config["DB_TYPE"]))
         )
         chat_handler.chat(message)
+    
+    def on_join_session(self, data):
+        """Explicitly join a session room (for reconnection)"""
+        session_id = data.get('session_id')
+        if session_id:
+            join_room(session_id)
+            emit('session_joined', {'session_id': session_id})
+            print(f"Client explicitly joined session room {session_id}")
+    
+    def on_disconnect(self):
+        """Handle client disconnection"""
+        print(f"Client disconnected from chat namespace")


### PR DESCRIPTION
## Current Scenario

1. The chat socket connection is created between server and client at the moment of initial connection.
2. Server keeps sending updates via the fixed connection via the respective connection's `request.sid`

**Problem**
If the user reloads the page, leaves the page or checks the same session on a different device they will not be able to see live updates

## Proposed Solution
- The user joins a room with the `session_id` we preserve in our `sessions` table
- The message are directed to a specific `room` which corresponds to the `session_id`
- Since the user will join the same room, even in multiple reconnections, the live updates are still available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-scoped real-time chat: clients join a session room and messages/updates are delivered only to that room.
  * Explicit "join session" support with confirmation; improved connect/disconnect handling.
  * New public method to update session state and reflect changes in real time.

* **Refactor**
  * Emissions now broadcast to session rooms with clearer logging.
  * Errors include session context for easier troubleshooting.
  * Message history persistence ensured after publish to keep conversations in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->