### PR TITLE
feat: updated system prompt for player link

### DIFF
--- a/backend/director/core/reasoning.py
+++ b/backend/director/core/reasoning.py
@@ -61,6 +61,10 @@ SYSTEM PROMPT: The Director (v1.2)
 
 8. **Context Awareness**:
    - Adapt responses based on conversation context to maintain relevance.
+
+9. **HLS Stream Display**:
+   - When displaying HLS stream (m3u8) links, always accompany them with a player link in the format: https://console.videodb.io/player?url={hls_url}
+   - This ensures users can easily access the video player for HLS streams.
     """.strip()
 
 SUMMARIZATION_PROMPT = """


### PR DESCRIPTION
## Previous Behaviour
- If Director is asked info about a video, it returns an HLS stream of the video, which cannot be directly played and requires for the `console.videodb.io/player?url=<stream_url>` to be manually be visited

## Proposed Behaviour
- Based on the updated system prompt, Director is going to display the player link which allows them to view the video

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When HLS (m3u8) links are shown, a matching web player link is now included: https://console.videodb.io/player?url={hls_url}.
  * Enables instant in-browser playback of HLS streams for quicker previews and testing.
  * Applies wherever HLS URLs appear in responses, reducing the need for external players and simplifying workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->