### PR TITLE
feat: Add SceneIndexAgent to display indexed scene descriptions

### DIFF
--- a/backend/director/agents/scene_index.py
+++ b/backend/director/agents/scene_index.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from director.agents.base import BaseAgent, AgentResponse, AgentStatus
 from director.core.session import Session, MsgStatus, TextContent
@@ -38,7 +39,7 @@ class SceneIndexAgent(BaseAgent):
         super().__init__(session=session, **kwargs)
 
     def run(
-        self, video_id: str, collection_id: str, scene_index_id: str = None
+        self, video_id: str, collection_id: str, scene_index_id: Optional[str] = None
     ) -> AgentResponse:
         """
         Display the indexed scene descriptions for a video as a formatted table.
@@ -72,7 +73,8 @@ class SceneIndexAgent(BaseAgent):
                         status=AgentStatus.ERROR,
                         message="No scene index found. Index the video scenes first.",
                     )
-                scene_index_id = scene_list[0]["scene_index_id"]
+                # Use the last entry: REST list APIs typically append, so newest is last.
+                scene_index_id = scene_list[-1]["scene_index_id"]
 
             self.output_message.actions.append("Loading scene descriptions...")
             self.output_message.push_update()
@@ -94,7 +96,8 @@ class SceneIndexAgent(BaseAgent):
             for i, scene in enumerate(scenes, 1):
                 start = f"{float(scene.get('start', 0)):.1f}s"
                 end = f"{float(scene.get('end', 0)):.1f}s"
-                desc = scene.get("description", "").replace("|", "\\|")
+                raw_desc = scene.get("description") or ""
+                desc = raw_desc.replace("\r", " ").replace("\n", " ").replace("|", "\\|")
                 rows.append(f"| {i} | {start} | {end} | {desc} |")
 
             output_text_content.text = "\n".join(rows)

--- a/backend/director/agents/scene_index.py
+++ b/backend/director/agents/scene_index.py
@@ -1,0 +1,120 @@
+import logging
+
+from director.agents.base import BaseAgent, AgentResponse, AgentStatus
+from director.core.session import Session, MsgStatus, TextContent
+from director.tools.videodb_tool import VideoDBTool
+
+logger = logging.getLogger(__name__)
+
+SCENE_INDEX_AGENT_PARAMETERS = {
+    "type": "object",
+    "properties": {
+        "video_id": {
+            "type": "string",
+            "description": "The ID of the video whose scene descriptions you want to view.",
+        },
+        "collection_id": {
+            "type": "string",
+            "description": "The ID of the collection containing the video.",
+        },
+        "scene_index_id": {
+            "type": "string",
+            "description": "Optional. The specific scene index ID to display. If omitted, the most recent scene index is used.",
+        },
+    },
+    "required": ["video_id", "collection_id"],
+}
+
+
+class SceneIndexAgent(BaseAgent):
+    def __init__(self, session: Session, **kwargs):
+        self.agent_name = "scene_index"
+        self.description = (
+            "Retrieve and display the indexed scene descriptions of a video. "
+            "Use this when the user wants to view, see, or list the scene descriptions "
+            "or scene index of a video that has already been scene-indexed."
+        )
+        self.parameters = SCENE_INDEX_AGENT_PARAMETERS
+        super().__init__(session=session, **kwargs)
+
+    def run(
+        self, video_id: str, collection_id: str, scene_index_id: str = None
+    ) -> AgentResponse:
+        """
+        Display the indexed scene descriptions for a video as a formatted table.
+
+        :param str video_id: The ID of the video
+        :param str collection_id: The ID of the collection containing the video
+        :param str scene_index_id: Optional scene index ID; uses the most recent index if not provided
+        """
+        output_text_content = TextContent(
+            agent_name=self.agent_name,
+            status_message="Fetching scene index...",
+        )
+        self.output_message.content.append(output_text_content)
+        self.output_message.push_update()
+
+        try:
+            videodb_tool = VideoDBTool(collection_id=collection_id)
+
+            if not scene_index_id:
+                self.output_message.actions.append("Listing available scene indexes...")
+                self.output_message.push_update()
+                scene_list = videodb_tool.list_scene_index(video_id)
+                if not scene_list:
+                    output_text_content.status = MsgStatus.error
+                    output_text_content.status_message = (
+                        "No scene index found for this video. "
+                        "Please index the video scenes first."
+                    )
+                    self.output_message.publish()
+                    return AgentResponse(
+                        status=AgentStatus.ERROR,
+                        message="No scene index found. Index the video scenes first.",
+                    )
+                scene_index_id = scene_list[0]["scene_index_id"]
+
+            self.output_message.actions.append("Loading scene descriptions...")
+            self.output_message.push_update()
+            scenes = videodb_tool.get_scene_index(video_id, scene_index_id)
+
+            if not scenes:
+                output_text_content.status = MsgStatus.error
+                output_text_content.status_message = "Scene index exists but contains no entries."
+                self.output_message.publish()
+                return AgentResponse(
+                    status=AgentStatus.ERROR,
+                    message="Scene index is empty.",
+                )
+
+            rows = [
+                "| # | Start | End | Description |",
+                "|---|---|---|---|",
+            ]
+            for i, scene in enumerate(scenes, 1):
+                start = f"{float(scene.get('start', 0)):.1f}s"
+                end = f"{float(scene.get('end', 0)):.1f}s"
+                desc = scene.get("description", "").replace("|", "\\|")
+                rows.append(f"| {i} | {start} | {end} | {desc} |")
+
+            output_text_content.text = "\n".join(rows)
+            output_text_content.status = MsgStatus.success
+            output_text_content.status_message = (
+                f"Showing {len(scenes)} scene descriptions."
+            )
+            self.output_message.publish()
+            return AgentResponse(
+                status=AgentStatus.SUCCESS,
+                message=f"Displayed {len(scenes)} scene descriptions.",
+                data={"scene_index_id": scene_index_id, "scene_count": len(scenes)},
+            )
+
+        except Exception as e:
+            logger.exception(f"SceneIndexAgent failed: {e}")
+            output_text_content.status = MsgStatus.error
+            output_text_content.status_message = "Failed to retrieve scene descriptions."
+            self.output_message.publish()
+            return AgentResponse(
+                status=AgentStatus.ERROR,
+                message=str(e),
+            )

--- a/backend/director/handler.py
+++ b/backend/director/handler.py
@@ -26,6 +26,7 @@ from director.agents.code_assistant import CodeAssistantAgent
 from director.agents.web_search_agent import WebSearchAgent
 from director.agents.clone_voice import CloneVoiceAgent
 from director.agents.voice_replacement import VoiceReplacementAgent
+from director.agents.scene_index import SceneIndexAgent
 
 
 from director.core.session import Session, InputMessage, MsgStatus
@@ -71,6 +72,7 @@ class ChatHandler:
             WebSearchAgent,
             VoiceReplacementAgent,
             PricingAgent,
+            SceneIndexAgent,
         ]
 
     def add_videodb_state(self, session):


### PR DESCRIPTION
## Summary

- Adds a new `SceneIndexAgent` (`backend/director/agents/scene_index.py`) that retrieves and displays indexed scene descriptions for a video
- Accepts `video_id`, `collection_id`, and an optional `scene_index_id` (defaults to most recent index)
- Outputs a formatted markdown table: `| # | Start | End | Description |`
- Registered in `ChatHandler` alongside all other agents

## How it works

1. Calls `list_scene_index(video_id)` to find available indexes (if no `scene_index_id` provided)
2. Calls `get_scene_index(video_id, scene_index_id)` to fetch scene records
3. Renders each scene as a table row with timestamp range and AI-generated description
4. Uses the standard `TextContent` + `push_update()` / `publish()` pattern

## Test plan

- [ ] Index a video's scenes using the existing index agent
- [ ] Ask "show me the scene descriptions for video X" — verify `scene_index` agent is selected by the ReasoningEngine
- [ ] Confirm markdown table renders with correct timestamps and descriptions
- [ ] Test error path: ask for scene descriptions on a video that hasn't been indexed — verify graceful error message

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scene index retrieval and display: users can view organized scene descriptions with start/end timestamps in a structured Markdown table.
  * Shows incremental status updates during retrieval and presents clear error messages if no index or scenes are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->