### PR TITLE
feat: sliding window context management for long sessions (closes #116)

### DIFF
--- a/backend/director/constants.py
+++ b/backend/director/constants.py
@@ -1,3 +1,4 @@
+import os
 from enum import Enum
 
 
@@ -30,4 +31,9 @@ class EnvPrefix(str, Enum):
     ANTHROPIC_ = "ANTHROPIC_"
     GOOGLEAI_ = "GOOGLEAI_"
 
-DOWNLOADS_PATH="director/downloads"
+DOWNLOADS_PATH = "director/downloads"
+
+# Maximum number of reasoning context messages retained per session.
+# Each agentic turn adds ~3-5 messages. Default: 20 msgs ≈ 5-7 turns.
+# Can be overridden via MAX_CONTEXT_MESSAGES env var.
+MAX_CONTEXT_MESSAGES = int(os.getenv("MAX_CONTEXT_MESSAGES", "20"))

--- a/backend/director/constants.py
+++ b/backend/director/constants.py
@@ -36,4 +36,9 @@ DOWNLOADS_PATH = "director/downloads"
 # Maximum number of reasoning context messages retained per session.
 # Each agentic turn adds ~3-5 messages. Default: 20 msgs ≈ 5-7 turns.
 # Can be overridden via MAX_CONTEXT_MESSAGES env var.
-MAX_CONTEXT_MESSAGES = int(os.getenv("MAX_CONTEXT_MESSAGES", "20"))
+try:
+    MAX_CONTEXT_MESSAGES = int(os.getenv("MAX_CONTEXT_MESSAGES", "20"))
+except ValueError:
+    MAX_CONTEXT_MESSAGES = 20
+# Minimum 2: one slot for the system prompt, one for the current user message.
+MAX_CONTEXT_MESSAGES = max(2, MAX_CONTEXT_MESSAGES)

--- a/backend/director/core/reasoning.py
+++ b/backend/director/core/reasoning.py
@@ -120,6 +120,8 @@ class ReasoningEngine:
 
     def _trim_context(self, max_messages: int) -> None:
         """Trim reasoning_context to at most max_messages, always preserving index 0 (system prompt)."""
+        # Enforce a floor of 2: system prompt + at least one message.
+        max_messages = max(2, max_messages)
         ctx = self.session.reasoning_context
         if len(ctx) <= max_messages:
             return
@@ -128,7 +130,8 @@ class ReasoningEngine:
             f"Context window trimmed: dropping {trimmed} oldest message(s) "
             f"({len(ctx)} → {max_messages})"
         )
-        self.session.reasoning_context = [ctx[0]] + ctx[-(max_messages - 1):]
+        tail_len = max_messages - 1
+        self.session.reasoning_context = [ctx[0], *ctx[-tail_len:]]
 
     def build_context(self):
         """Build the context for the reasoning engine it adds the information about the video or collection to the reasoning context."""
@@ -248,9 +251,13 @@ class ReasoningEngine:
                     "maximum context length",
                     "reduce the length",
                 )
-                if any(s in llm_response.content for s in context_length_signals):
+                content_lower = llm_response.content.lower()
+                if (
+                    any(s in content_lower for s in context_length_signals)
+                    and len(self.session.reasoning_context) > 5
+                ):
                     logger.warning("Context length exceeded — trimming and retrying")
-                    self._trim_context(max(5, len(self.session.reasoning_context) // 2))
+                    self._trim_context(max(2, len(self.session.reasoning_context) // 2))
                     llm_response = self.llm.chat_completions(
                         messages=[
                             m.to_llm_msg() for m in self.session.reasoning_context

--- a/backend/director/core/reasoning.py
+++ b/backend/director/core/reasoning.py
@@ -3,6 +3,7 @@ from typing import List
 
 
 from director.agents.base import BaseAgent, AgentStatus, AgentResponse
+from director.constants import MAX_CONTEXT_MESSAGES
 from director.core.session import (
     Session,
     OutputMessage,
@@ -117,12 +118,25 @@ class ReasoningEngine:
         """
         self.agents.extend(agents)
 
+    def _trim_context(self, max_messages: int) -> None:
+        """Trim reasoning_context to at most max_messages, always preserving index 0 (system prompt)."""
+        ctx = self.session.reasoning_context
+        if len(ctx) <= max_messages:
+            return
+        trimmed = len(ctx) - max_messages
+        logger.warning(
+            f"Context window trimmed: dropping {trimmed} oldest message(s) "
+            f"({len(ctx)} → {max_messages})"
+        )
+        self.session.reasoning_context = [ctx[0]] + ctx[-(max_messages - 1):]
+
     def build_context(self):
         """Build the context for the reasoning engine it adds the information about the video or collection to the reasoning context."""
         input_context = ContextMessage(
             content=self.input_message.content, role=RoleTypes.user
         )
         if self.session.reasoning_context:
+            self._trim_context(MAX_CONTEXT_MESSAGES)
             self.session.reasoning_context.append(input_context)
         else:
             if self.session.video_id:
@@ -228,19 +242,37 @@ class ReasoningEngine:
             logger.info(f"LLM Response: {llm_response}")
 
             if not llm_response.status:
-                self.output_message.content.append(
-                    TextContent(
-                        text=llm_response.content,
-                        status=MsgStatus.error,
-                        status_message="Error in reasoning",
-                        agent_name="assistant",
-                    )
+                context_length_signals = (
+                    "context_length_exceeded",
+                    "prompt is too long",
+                    "maximum context length",
+                    "reduce the length",
                 )
-                self.output_message.actions.append("Failed to reason the message")
-                self.output_message.status = MsgStatus.error
-                self.output_message.publish()
-                self.stop()
-                break
+                if any(s in llm_response.content for s in context_length_signals):
+                    logger.warning("Context length exceeded — trimming and retrying")
+                    self._trim_context(max(5, len(self.session.reasoning_context) // 2))
+                    llm_response = self.llm.chat_completions(
+                        messages=[
+                            m.to_llm_msg() for m in self.session.reasoning_context
+                        ]
+                        + temp_messages,
+                        tools=[agent.to_llm_format() for agent in self.agents],
+                    )
+
+                if not llm_response.status:
+                    self.output_message.content.append(
+                        TextContent(
+                            text=llm_response.content,
+                            status=MsgStatus.error,
+                            status_message="Error in reasoning",
+                            agent_name="assistant",
+                        )
+                    )
+                    self.output_message.actions.append("Failed to reason the message")
+                    self.output_message.status = MsgStatus.error
+                    self.output_message.publish()
+                    self.stop()
+                    break
 
             if llm_response.tool_calls:
                 if self.summary_content:

--- a/backend/director/llm/anthropic.py
+++ b/backend/director/llm/anthropic.py
@@ -157,7 +157,7 @@ class AnthropicAI(BaseLLM):
         try:
             response = self.client.messages.create(**params)
         except Exception as e:
-            raise e
+            logger.exception("Anthropic LLM call failed")
             return LLMResponse(content=f"Error: {e}")
 
         return LLMResponse(

--- a/backend/director/llm/anthropic.py
+++ b/backend/director/llm/anthropic.py
@@ -1,3 +1,4 @@
+import logging
 from enum import Enum
 
 from pydantic import Field, field_validator, FieldValidationInfo
@@ -9,6 +10,8 @@ from director.constants import (
     LLMType,
     EnvPrefix,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class AnthropicChatModel(str, Enum):


### PR DESCRIPTION
## Summary

- **Sliding window trim**: `ReasoningEngine._trim_context(max_messages)` keeps `reasoning_context[0]` (the system+metadata prompt) and evicts the oldest messages beyond the threshold before each LLM call. Called from `build_context()` on every turn after the first.
- **Env-configurable limit**: `MAX_CONTEXT_MESSAGES` constant in `constants.py` defaults to `20` (≈5-7 agentic turns) and can be overridden via the `MAX_CONTEXT_MESSAGES` env var without code changes.
- **Context-length safety net**: `step()` detects common context-length error strings from both OpenAI and Anthropic, trims to half the current length, and retries once before surfacing an error to the user.
- **Anthropic crash fix**: the `raise e` at `anthropic.py:159` made the `return LLMResponse(...)` line below it unreachable dead code, crashing the engine on any Anthropic API error. Replaced with `logger.exception(...)` + `return LLMResponse(content=f"Error: {e}")` so Anthropic sessions degrade gracefully.

## Test plan

- [ ] Start backend and have a multi-turn conversation that generates >20 context messages — verify the session doesn't error and oldest turns are silently dropped
- [ ] Set `MAX_CONTEXT_MESSAGES=4` in `.env` and confirm aggressive trimming kicks in after a few turns (visible in backend warning logs)
- [ ] Confirm `reasoning_context[0]` (system prompt with video/collection metadata) is always preserved after trimming
- [ ] Simulate a context-length error by patching the LLM response to return `"Error: context_length_exceeded"` — verify the retry fires and a trimmed response is returned
- [ ] Verify existing short sessions (≤20 messages) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable conversation history limit with safeguards to preserve essential system context

* **Bug Fixes**
  * Improved recovery when context limits are exceeded by automatically trimming and retrying
  * More graceful handling of external API errors to prevent session interruptions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->