### PR TITLE
feat: add stop generation feature

### DIFF
--- a/backend/director/agents/clone_voice.py
+++ b/backend/director/agents/clone_voice.py
@@ -3,6 +3,7 @@ import os
 import requests
 import uuid
 import base64
+from typing import Optional
 from director.agents.base import BaseAgent, AgentResponse, AgentStatus
 from director.core.session import Session, MsgStatus, TextContent
 from director.tools.elevenlabs import ElevenLabsTool
@@ -78,7 +79,7 @@ class CloneVoiceAgent(BaseAgent):
         super().__init__(session=session, **kwargs)
         
 
-    def _download_audio_file(self, audio_url: str) -> str | None:
+    def _download_audio_file(self, audio_url: str) -> Optional[str]:
         os.makedirs(DOWNLOADS_PATH, exist_ok=True)
         try:
             self.output_message.actions.append("Downloading sample audio URL")
@@ -101,7 +102,7 @@ class CloneVoiceAgent(BaseAgent):
             logger.error(f"Failed to download {audio_url}: {e}")
             return None
         
-    def _download_video_file(self, video_url: str) -> str | None:
+    def _download_video_file(self, video_url: str) -> Optional[str]:
         os.makedirs(DOWNLOADS_PATH, exist_ok=True)
 
         try:
@@ -124,7 +125,7 @@ class CloneVoiceAgent(BaseAgent):
             print(f"Failed to download {video_url}: {e}")
             return None
         
-    def _download_audio_from_video(self, audio_source: dict) -> str | None:
+    def _download_audio_from_video(self, audio_source: dict) -> Optional[str]:
         required_keys = {"video_id", "collection_id", "start_time", "end_time"}
         if not isinstance(audio_source, dict) or not required_keys.issubset(audio_source.keys()):
             return None

--- a/backend/director/entrypoint/api/routes.py
+++ b/backend/director/entrypoint/api/routes.py
@@ -1,10 +1,10 @@
 import os
 
-from flask import Blueprint, request, current_app as app
+from flask import Blueprint, jsonify, request, current_app as app
 from werkzeug.utils import secure_filename
 
 from director.db import load_db
-from director.handler import ChatHandler, SessionHandler, VideoDBHandler, ConfigHandler
+from director.handler import ChatHandler, SessionHandler, VideoDBHandler, ConfigHandler, _active_engines
 
 
 agent_bp = Blueprint("agent", __name__, url_prefix="/agent")
@@ -60,6 +60,16 @@ def get_session(session_id):
             return {
                 "message": f"Failed to delete the entry for following components: {', '.join(failed_components)}"
             }, 500
+
+
+@session_bp.route("/<session_id>/stop", methods=["POST"])
+def stop_session(session_id):
+    """Stop an in-progress generation for the given session."""
+    engine = _active_engines.get(session_id)
+    if engine:
+        engine.stop()
+        return jsonify({"message": "Generation stopped."}), 200
+    return jsonify({"message": "No active generation found."}), 404
 
 
 @videodb_bp.route("/collection", defaults={"collection_id": None}, methods=["GET"])

--- a/backend/director/entrypoint/api/routes.py
+++ b/backend/director/entrypoint/api/routes.py
@@ -4,7 +4,7 @@ from flask import Blueprint, jsonify, request, current_app as app
 from werkzeug.utils import secure_filename
 
 from director.db import load_db
-from director.handler import ChatHandler, SessionHandler, VideoDBHandler, ConfigHandler, _active_engines
+from director.handler import ChatHandler, SessionHandler, VideoDBHandler, ConfigHandler, _active_engines, _active_engines_lock
 
 
 agent_bp = Blueprint("agent", __name__, url_prefix="/agent")
@@ -65,7 +65,8 @@ def get_session(session_id):
 @session_bp.route("/<session_id>/stop", methods=["POST"])
 def stop_session(session_id):
     """Stop an in-progress generation for the given session."""
-    engine = _active_engines.get(session_id)
+    with _active_engines_lock:
+        engine = _active_engines.get(session_id)
     if engine:
         engine.stop()
         return jsonify({"message": "Generation stopped."}), 200
@@ -273,4 +274,5 @@ def config_check():
         config_handler = ConfigHandler()
         return config_handler.check()
     except Exception:
+        app.logger.exception("config_check failed; returning all-False flags")
         return jsonify({"videodb_configured": False, "llm_configured": False, "db_configured": False}), 200

--- a/backend/director/entrypoint/api/routes.py
+++ b/backend/director/entrypoint/api/routes.py
@@ -268,5 +268,9 @@ def upload_video(collection_id):
 
 @config_bp.route("/check", methods=["GET"])
 def config_check():
-    config_handler = ConfigHandler()
-    return config_handler.check()
+    """Return the server configuration status. Always returns 200 with boolean flags."""
+    try:
+        config_handler = ConfigHandler()
+        return config_handler.check()
+    except Exception:
+        return jsonify({"videodb_configured": False, "llm_configured": False, "db_configured": False}), 200

--- a/backend/director/entrypoint/api/socket_io.py
+++ b/backend/director/entrypoint/api/socket_io.py
@@ -28,6 +28,9 @@ class ChatNamespace(Namespace):
         stop for any session_id. If you deploy Director in a shared environment,
         add session-ownership verification here before calling engine.stop().
         """
+        if not isinstance(message, dict):
+            logger.warning("stop_generation received invalid payload: %r", message)
+            return
         session_id = message.get("session_id")
         if not session_id:
             logger.warning("stop_generation received without session_id")

--- a/backend/director/entrypoint/api/socket_io.py
+++ b/backend/director/entrypoint/api/socket_io.py
@@ -21,7 +21,13 @@ class ChatNamespace(Namespace):
         chat_handler.chat(message)
 
     def on_stop_generation(self, message):
-        """Stop an in-progress generation for the given session_id."""
+        """Stop an in-progress generation for the given session_id.
+
+        Note: Director is designed for single-user local deployments; there is
+        no multi-user authentication layer. Any connected client can request a
+        stop for any session_id. If you deploy Director in a shared environment,
+        add session-ownership verification here before calling engine.stop().
+        """
         session_id = message.get("session_id")
         if not session_id:
             logger.warning("stop_generation received without session_id")

--- a/backend/director/entrypoint/api/socket_io.py
+++ b/backend/director/entrypoint/api/socket_io.py
@@ -1,10 +1,13 @@
 import os
+import logging
 
 from flask import current_app as app
 from flask_socketio import Namespace
 
 from director.db import load_db
-from director.handler import ChatHandler
+from director.handler import ChatHandler, _active_engines
+
+logger = logging.getLogger(__name__)
 
 
 class ChatNamespace(Namespace):
@@ -16,3 +19,16 @@ class ChatNamespace(Namespace):
             db=load_db(os.getenv("SERVER_DB_TYPE", app.config["DB_TYPE"]))
         )
         chat_handler.chat(message)
+
+    def on_stop_generation(self, message):
+        """Stop an in-progress generation for the given session_id."""
+        session_id = message.get("session_id")
+        if not session_id:
+            logger.warning("stop_generation received without session_id")
+            return
+        engine = _active_engines.get(session_id)
+        if engine:
+            logger.info(f"Stopping generation for session {session_id}")
+            engine.stop()
+        else:
+            logger.info(f"No active generation found for session {session_id}")

--- a/backend/director/entrypoint/api/socket_io.py
+++ b/backend/director/entrypoint/api/socket_io.py
@@ -5,7 +5,7 @@ from flask import current_app as app
 from flask_socketio import Namespace
 
 from director.db import load_db
-from director.handler import ChatHandler, _active_engines
+from director.handler import ChatHandler, _active_engines, _active_engines_lock
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,8 @@ class ChatNamespace(Namespace):
         if not session_id:
             logger.warning("stop_generation received without session_id")
             return
-        engine = _active_engines.get(session_id)
+        with _active_engines_lock:
+            engine = _active_engines.get(session_id)
         if engine:
             logger.info(f"Stopping generation for session {session_id}")
             engine.stop()

--- a/backend/director/handler.py
+++ b/backend/director/handler.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import threading
 
 from director.agents.frame import FrameAgent
 from director.agents.summarize_video import SummarizeVideoAgent
@@ -42,6 +43,7 @@ logger = logging.getLogger(__name__)
 # Registry of currently running ReasoningEngine instances keyed by session_id.
 # Used by on_stop_generation to cancel an in-progress generation.
 _active_engines: dict = {}
+_active_engines_lock = threading.Lock()
 
 
 class ChatHandler:
@@ -124,18 +126,20 @@ class ChatHandler:
             else:
                 res_eng.register_agents(agents)
 
-            if session.session_id in _active_engines:
-                logger.warning(
-                    f"Generation already running for session {session.session_id}, ignoring duplicate"
-                )
-                session.output_message.update_status(MsgStatus.error)
-                return
-            _active_engines[session.session_id] = res_eng
+            with _active_engines_lock:
+                if session.session_id in _active_engines:
+                    logger.warning(
+                        f"Generation already running for session {session.session_id}, ignoring duplicate"
+                    )
+                    session.output_message.update_status(MsgStatus.error)
+                    return
+                _active_engines[session.session_id] = res_eng
             try:
                 res_eng.run()
             finally:
-                if _active_engines.get(session.session_id) is res_eng:
-                    _active_engines.pop(session.session_id, None)
+                with _active_engines_lock:
+                    if _active_engines.get(session.session_id) is res_eng:
+                        _active_engines.pop(session.session_id, None)
                 if res_eng.stop_flag:
                     session.output_message.update_status(MsgStatus.error)
 
@@ -231,15 +235,13 @@ class VideoDBHandler:
 class ConfigHandler:
     def check(self):
         """Check the configuration of the server."""
-        try:
-            videodb_configured = bool(os.getenv("VIDEO_DB_API_KEY"))
-        except Exception:
-            videodb_configured = False
+        videodb_configured = bool(os.getenv("VIDEO_DB_API_KEY"))
 
         try:
             db = load_db(os.getenv("SERVER_DB_TYPE", os.getenv("DB_TYPE", "sqlite")))
             db_configured = db.health_check()
         except Exception:
+            logger.exception("Failed to check database configuration")
             db_configured = False
 
         return {

--- a/backend/director/handler.py
+++ b/backend/director/handler.py
@@ -78,6 +78,7 @@ class ChatHandler:
         ]
 
     def add_videodb_state(self, session):
+        """Populate session.state with a VideoDB connection, collection, and optionally a video."""
         from videodb import connect
 
         session.state["conn"] = connect(
@@ -92,6 +93,7 @@ class ChatHandler:
             )
 
     def agents_list(self):
+        """Return a list of agent name/description dicts for all registered agents."""
         return [
             {
                 "name": agent_instance.name,
@@ -102,6 +104,7 @@ class ChatHandler:
         ]
 
     def chat(self, message):
+        """Process an incoming chat message, run the reasoning engine, and stream the response."""
         logger.info(f"ChatHandler input message: {message}")
 
         session = Session(db=self.db, **message)
@@ -125,12 +128,14 @@ class ChatHandler:
                 logger.warning(
                     f"Generation already running for session {session.session_id}, ignoring duplicate"
                 )
+                session.output_message.update_status(MsgStatus.error)
                 return
             _active_engines[session.session_id] = res_eng
             try:
                 res_eng.run()
             finally:
-                _active_engines.pop(session.session_id, None)
+                if _active_engines.get(session.session_id) is res_eng:
+                    _active_engines.pop(session.session_id, None)
                 if res_eng.stop_flag:
                     session.output_message.update_status(MsgStatus.error)
 
@@ -226,10 +231,17 @@ class VideoDBHandler:
 class ConfigHandler:
     def check(self):
         """Check the configuration of the server."""
-        videodb_configured = True if os.getenv("VIDEO_DB_API_KEY") else False
+        try:
+            videodb_configured = bool(os.getenv("VIDEO_DB_API_KEY"))
+        except Exception:
+            videodb_configured = False
 
-        db = load_db(os.getenv("SERVER_DB_TYPE", os.getenv("DB_TYPE", "sqlite")))
-        db_configured = db.health_check()
+        try:
+            db = load_db(os.getenv("SERVER_DB_TYPE", os.getenv("DB_TYPE", "sqlite")))
+            db_configured = db.health_check()
+        except Exception:
+            db_configured = False
+
         return {
             "videodb_configured": videodb_configured,
             "llm_configured": True,

--- a/backend/director/handler.py
+++ b/backend/director/handler.py
@@ -121,6 +121,11 @@ class ChatHandler:
             else:
                 res_eng.register_agents(agents)
 
+            if session.session_id in _active_engines:
+                logger.warning(
+                    f"Generation already running for session {session.session_id}, ignoring duplicate"
+                )
+                return
             _active_engines[session.session_id] = res_eng
             try:
                 res_eng.run()

--- a/backend/director/handler.py
+++ b/backend/director/handler.py
@@ -110,6 +110,15 @@ class ChatHandler:
         logger.info(f"ChatHandler input message: {message}")
 
         session = Session(db=self.db, **message)
+
+        # Reject duplicates before any DB writes or progress events.
+        with _active_engines_lock:
+            if session.session_id in _active_engines:
+                logger.warning(
+                    f"Generation already running for session {session.session_id}, ignoring duplicate"
+                )
+                return
+
         session.create()
         input_message = InputMessage(db=self.db, **message)
         input_message.publish()
@@ -126,10 +135,11 @@ class ChatHandler:
             else:
                 res_eng.register_agents(agents)
 
+            # Second check-and-claim to cover the window between the early check and engine creation.
             with _active_engines_lock:
                 if session.session_id in _active_engines:
                     logger.warning(
-                        f"Generation already running for session {session.session_id}, ignoring duplicate"
+                        f"Generation already running for session {session.session_id}, ignoring duplicate (late check)"
                     )
                     session.output_message.update_status(MsgStatus.error)
                     return

--- a/backend/director/handler.py
+++ b/backend/director/handler.py
@@ -39,6 +39,10 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
+# Registry of currently running ReasoningEngine instances keyed by session_id.
+# Used by on_stop_generation to cancel an in-progress generation.
+_active_engines: dict = {}
+
 
 class ChatHandler:
     def __init__(self, db, **kwargs):
@@ -117,7 +121,13 @@ class ChatHandler:
             else:
                 res_eng.register_agents(agents)
 
-            res_eng.run()
+            _active_engines[session.session_id] = res_eng
+            try:
+                res_eng.run()
+            finally:
+                _active_engines.pop(session.session_id, None)
+                if res_eng.stop_flag:
+                    session.output_message.update_status(MsgStatus.error)
 
         except Exception as e:
             session.output_message.update_status(MsgStatus.error)

--- a/frontend/src/views/DefaultView.vue
+++ b/frontend/src/views/DefaultView.vue
@@ -13,10 +13,13 @@ const stopGeneration = async () => {
   if (currentSessionId.value) {
     stopPending.value = true;
     isGenerating.value = false;
-    await fetch(`${BACKEND_URL}/session/${currentSessionId.value}/stop`, {
-      method: "POST",
-    });
-    stopPending.value = false;
+    try {
+      await fetch(`${BACKEND_URL}/session/${currentSessionId.value}/stop`, {
+        method: "POST",
+      });
+    } finally {
+      stopPending.value = false;
+    }
   }
 };
 
@@ -27,7 +30,9 @@ watch(
   (convs) => {
     if (!convs || stopPending.value) return;
     for (const convMessages of Object.values(convs)) {
+      if (!convMessages) continue;
       for (const msg of Object.values(convMessages)) {
+        if (!msg) continue;
         if (msg.sender === "assistant" && msg.status === "progress") {
           isGenerating.value = true;
           currentSessionId.value = msg.session_id;

--- a/frontend/src/views/DefaultView.vue
+++ b/frontend/src/views/DefaultView.vue
@@ -7,13 +7,16 @@ const BACKEND_URL = import.meta.env.VITE_APP_BACKEND_URL;
 const chatInterfaceRef = ref(null);
 const isGenerating = ref(false);
 const currentSessionId = ref(null);
+const stopPending = ref(false);
 
 const stopGeneration = async () => {
   if (currentSessionId.value) {
+    stopPending.value = true;
     isGenerating.value = false;
     await fetch(`${BACKEND_URL}/session/${currentSessionId.value}/stop`, {
       method: "POST",
     });
+    stopPending.value = false;
   }
 };
 
@@ -22,7 +25,7 @@ const stopGeneration = async () => {
 watch(
   () => chatInterfaceRef.value?.conversations,
   (convs) => {
-    if (!convs) return;
+    if (!convs || stopPending.value) return;
     for (const convMessages of Object.values(convs)) {
       for (const msg of Object.values(convMessages)) {
         if (msg.sender === "assistant" && msg.status === "progress") {
@@ -66,7 +69,9 @@ onUnmounted(() => {
     />
     <button
       v-if="isGenerating"
+      type="button"
       class="stop-btn"
+      aria-label="Stop generation"
       @click="stopGeneration"
       title="Stop generation"
     >

--- a/frontend/src/views/DefaultView.vue
+++ b/frontend/src/views/DefaultView.vue
@@ -1,10 +1,41 @@
 <script setup>
-import { ref, onMounted, onUnmounted } from "vue";
+import { ref, watch, onMounted, onUnmounted } from "vue";
 import { ChatInterface } from "@videodb/chat-vue";
 import "@videodb/chat-vue/dist/style.css";
 
 const BACKEND_URL = import.meta.env.VITE_APP_BACKEND_URL;
 const chatInterfaceRef = ref(null);
+const isGenerating = ref(false);
+const currentSessionId = ref(null);
+
+const stopGeneration = async () => {
+  if (currentSessionId.value) {
+    isGenerating.value = false;
+    await fetch(`${BACKEND_URL}/session/${currentSessionId.value}/stop`, {
+      method: "POST",
+    });
+  }
+};
+
+// Watch the chat component's conversations reactive object for in-progress assistant messages.
+// conversations shape: { [conv_id]: { [msg_id]: { session_id, status, sender, ... } } }
+watch(
+  () => chatInterfaceRef.value?.conversations,
+  (convs) => {
+    if (!convs) return;
+    for (const convMessages of Object.values(convs)) {
+      for (const msg of Object.values(convMessages)) {
+        if (msg.sender === "assistant" && msg.status === "progress") {
+          isGenerating.value = true;
+          currentSessionId.value = msg.session_id;
+          return;
+        }
+      }
+    }
+    isGenerating.value = false;
+  },
+  { deep: true }
+);
 
 const handleKeyDown = (event) => {
   if ((event.ctrlKey || event.metaKey) && event.key === "k") {
@@ -13,9 +44,11 @@ const handleKeyDown = (event) => {
     chatInterfaceRef.value.chatInputRef.focus();
   }
 };
+
 onMounted(() => {
   window.addEventListener("keydown", handleKeyDown);
 });
+
 onUnmounted(() => {
   window.removeEventListener("keydown", handleKeyDown);
 });
@@ -31,6 +64,14 @@ onUnmounted(() => {
         debug: true,
       }"
     />
+    <button
+      v-if="isGenerating"
+      class="stop-btn"
+      @click="stopGeneration"
+      title="Stop generation"
+    >
+      &#9632; Stop
+    </button>
   </main>
 </template>
 
@@ -82,5 +123,30 @@ html {
 * {
   scrollbar-width: thin; /* Makes the scrollbar narrower */
   scrollbar-color: #888 #f1f1f1; /* Thumb and track colors */
+}
+
+.stop-btn {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1a1a1a;
+  color: #fff;
+  border: 1px solid #444;
+  border-radius: 20px;
+  padding: 8px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  transition: background 0.15s;
+}
+
+.stop-btn:hover {
+  background: #333;
 }
 </style>


### PR DESCRIPTION
## Summary

Closes #84

Adds the ability to stop a long-running agent generation mid-flight. Currently, once a prompt is submitted there is no way to cancel it — this PR connects the existing (but unexposed) \`stop_flag\` mechanism in \`ReasoningEngine\` to a new HTTP endpoint and a UI stop button.

## Changes

### Backend — \`backend/director/handler.py\`
- Added a module-level \`_active_engines\` dict (protected by a \`threading.Lock\`) mapping \`session_id → ReasoningEngine\`
- Duplicate-session check happens before any DB writes or progress events; a second atomic check-and-claim runs after engine creation to close the race window
- Cleans up the registry in a \`finally\` block (handles crashes too)
- If the engine was stopped, marks the output message as \`error\` so the frontend spinner clears

### Backend — \`backend/director/entrypoint/api/socket_io.py\`
- Added \`on_stop_generation()\` handler — Flask-SocketIO routes the \`stop_generation\` WebSocket event here automatically
- Guards against non-dict payloads before calling \`.get()\`
- Looks up the running engine by \`session_id\` (under the shared lock) and calls \`engine.stop()\`

### Backend — \`backend/director/entrypoint/api/routes.py\`
- Added \`POST /session/<session_id>/stop\` HTTP endpoint as an alternative stop path
- \`/config/check\` now always returns valid JSON (with logging) so the frontend never receives an undefined config response

### Frontend — \`frontend/src/views/DefaultView.vue\`
- Watches \`chatInterfaceRef.value?.conversations\` (deep) to detect in-progress assistant messages
- Shows a fixed **"■ Stop"** button (bottom-center) only while \`status === "progress"\`
- Clicking it POSTs to \`/session/{session_id}/stop\`; \`stopPending\` flag prevents the watcher from re-enabling the button on a delayed progress event
- \`stopPending\` is always reset in a \`finally\` block even if the fetch fails

## How it works

\`ReasoningEngine\` already had \`stop_flag\` and \`stop()\` wired into the \`run()\` loop — the flag is checked at the top of every reasoning iteration. This PR connects that internal mechanism to an external signal.

\`\`\`
User clicks Stop
  → frontend POSTs /session/{session_id}/stop
    → stop_session() looks up _active_engines[session_id]
      → engine.stop() sets stop_flag = True
        → run() loop exits at next iteration check
          → finally block clears registry + updates status
\`\`\`

## Test plan

- [ ] Start a long-running generation (e.g. upload + summarize a video)
- [ ] Click the **■ Stop** button while the spinner is active
- [ ] Confirm the generation halts and the spinner clears
- [ ] Confirm a new prompt can be submitted immediately after stopping
- [ ] Confirm normal completions (no stop) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)