### PR TITLE
feat: add TwelveLabs video understanding agent (Pegasus + Marengo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ https://github.com/user-attachments/assets/33e0e7b4-9eb2-4a26-8274-f96c2c1c3a48
 ## ⭐️ Key Features
 ### 🤖 20+ pre-built video agents that you can customize to 
 * Summarize videos in seconds.
+* Understand videos multimodally (visual + audio) with TwelveLabs Pegasus.
 * Generate full movies with voiceovers from a script.
 * Search and index your media library.
 * Organize and clip your content effortlessly.

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -23,6 +23,10 @@ GOOGLEAI_API_KEY=
 # Tools
 REPLICATE_API_TOKEN=
 
+# Video Understanding Agent
+## TwelveLabs (Pegasus video analysis + Marengo embeddings)
+TWELVELABS_API_KEY=
+
 # Brandkit Agent
 INTRO_VIDEO_ID=
 OUTRO_VIDEO_ID=

--- a/backend/director/agents/video_understanding.py
+++ b/backend/director/agents/video_understanding.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Optional
 
 from director.agents.base import BaseAgent, AgentResponse, AgentStatus
 from director.core.session import Session, TextContent, MsgStatus
@@ -65,7 +66,7 @@ class VideoUnderstandingAgent(BaseAgent):
         collection_id: str,
         video_id: str,
         prompt: str,
-        twelvelabs_config: dict = None,
+        twelvelabs_config: Optional[dict] = None,
         *args,
         **kwargs,
     ) -> AgentResponse:
@@ -105,12 +106,12 @@ class VideoUnderstandingAgent(BaseAgent):
             self.output_message.actions.append("Resolving a downloadable video URL..")
             self.output_message.push_update()
             download_response = videodb_tool.download(video["stream_url"])
-            if download_response.get("status") != "done":
+            video_url = download_response.get("download_url")
+            if download_response.get("status") != "done" or not video_url:
                 raise Exception(
                     f"Could not resolve a downloadable URL for video {video_id}: "
                     f"{download_response}"
                 )
-            video_url = download_response["download_url"]
 
             self.output_message.actions.append(
                 "Analyzing video with <b>TwelveLabs Pegasus</b>.."

--- a/backend/director/agents/video_understanding.py
+++ b/backend/director/agents/video_understanding.py
@@ -1,0 +1,142 @@
+import logging
+import os
+
+from director.agents.base import BaseAgent, AgentResponse, AgentStatus
+from director.core.session import Session, TextContent, MsgStatus
+from director.tools.videodb_tool import VideoDBTool
+from director.tools.twelvelabs_tool import (
+    TwelveLabsTool,
+    PARAMS_CONFIG as TWELVELABS_PARAMS_CONFIG,
+)
+
+logger = logging.getLogger(__name__)
+
+VIDEO_UNDERSTANDING_AGENT_PARAMETERS = {
+    "type": "object",
+    "properties": {
+        "collection_id": {
+            "type": "string",
+            "description": "The collection_id where the given video_id is available.",
+        },
+        "video_id": {
+            "type": "string",
+            "description": "The id of the video to analyze.",
+        },
+        "prompt": {
+            "type": "string",
+            "description": "The instruction guiding the analysis, e.g. 'Describe this video', 'List the key moments', 'What products appear?'.",
+        },
+        "twelvelabs_config": {
+            "type": "object",
+            "properties": TWELVELABS_PARAMS_CONFIG["analyze"],
+            "description": "Optional TwelveLabs Pegasus configuration overrides.",
+        },
+    },
+    "required": ["collection_id", "video_id", "prompt"],
+}
+
+
+class VideoUnderstandingAgent(BaseAgent):
+    """Multimodal video understanding using TwelveLabs Pegasus.
+
+    Unlike ``summarize_video``, which reasons over the spoken-word transcript
+    only, this agent sends the actual video to TwelveLabs Pegasus so the
+    analysis is grounded in the visual content (scenes, objects, on-screen
+    actions) as well as the audio. Requires ``TWELVELABS_API_KEY`` to be set;
+    if it is not, the agent reports an error and existing behaviour is
+    unaffected.
+    """
+
+    def __init__(self, session: Session, **kwargs):
+        self.agent_name = "video_understanding"
+        self.description = (
+            "Analyzes a VideoDB video using the TwelveLabs Pegasus model for true "
+            "multimodal video understanding (visual + audio), not just the transcript. "
+            "Use this when the user asks about what is visually happening in a video, "
+            "wants a description grounded in the footage, or asks questions that need "
+            "the model to watch the video. Requires the TWELVELABS_API_KEY environment "
+            "variable."
+        )
+        self.parameters = VIDEO_UNDERSTANDING_AGENT_PARAMETERS
+        super().__init__(session=session, **kwargs)
+
+    def run(
+        self,
+        collection_id: str,
+        video_id: str,
+        prompt: str,
+        twelvelabs_config: dict = None,
+        *args,
+        **kwargs,
+    ) -> AgentResponse:
+        """
+        Analyze the given video with TwelveLabs Pegasus.
+
+        :param str collection_id: The collection_id where the video is available.
+        :param str video_id: The id of the video to analyze.
+        :param str prompt: The instruction guiding the analysis.
+        :param dict twelvelabs_config: Optional Pegasus configuration overrides.
+        :param args: Additional positional arguments.
+        :param kwargs: Additional keyword arguments.
+        :return: The response containing the generated analysis.
+        :rtype: AgentResponse
+        """
+        text_content = TextContent(
+            agent_name=self.agent_name,
+            status_message="Analyzing video with TwelveLabs Pegasus..",
+        )
+        try:
+            api_key = os.getenv("TWELVELABS_API_KEY")
+            if not api_key:
+                raise Exception(
+                    "TwelveLabs API key not found. Set the TWELVELABS_API_KEY "
+                    "environment variable to use the video_understanding agent."
+                )
+
+            self.output_message.actions.append("Started video understanding..")
+            self.output_message.content.append(text_content)
+            self.output_message.push_update()
+
+            videodb_tool = VideoDBTool(collection_id=collection_id)
+            video = videodb_tool.get_video(video_id)
+
+            # Pegasus fetches the video server-side from a public URL, so we
+            # resolve a downloadable URL from the VideoDB stream.
+            self.output_message.actions.append("Resolving a downloadable video URL..")
+            self.output_message.push_update()
+            download_response = videodb_tool.download(video["stream_url"])
+            if download_response.get("status") != "done":
+                raise Exception(
+                    f"Could not resolve a downloadable URL for video {video_id}: "
+                    f"{download_response}"
+                )
+            video_url = download_response["download_url"]
+
+            self.output_message.actions.append(
+                "Analyzing video with <b>TwelveLabs Pegasus</b>.."
+            )
+            self.output_message.push_update()
+
+            twelvelabs_tool = TwelveLabsTool(api_key=api_key)
+            analysis = twelvelabs_tool.analyze_video(
+                video_url=video_url,
+                prompt=prompt,
+                config=twelvelabs_config or {},
+            )
+
+            text_content.text = analysis
+            text_content.status = MsgStatus.success
+            text_content.status_message = "Here is the video analysis"
+            self.output_message.publish()
+        except Exception as e:
+            logger.exception(f"Error in {self.agent_name} agent: {e}")
+            text_content.status = MsgStatus.error
+            text_content.status_message = "Failed to analyze the video."
+            self.output_message.publish()
+            return AgentResponse(status=AgentStatus.ERROR, message=str(e))
+
+        return AgentResponse(
+            status=AgentStatus.SUCCESS,
+            message="Video analysis generated and displayed to user.",
+            data={"analysis": analysis},
+        )

--- a/backend/director/handler.py
+++ b/backend/director/handler.py
@@ -26,6 +26,7 @@ from director.agents.code_assistant import CodeAssistantAgent
 from director.agents.web_search_agent import WebSearchAgent
 from director.agents.clone_voice import CloneVoiceAgent
 from director.agents.voice_replacement import VoiceReplacementAgent
+from director.agents.video_understanding import VideoUnderstandingAgent
 
 
 from director.core.session import Session, InputMessage, MsgStatus
@@ -70,6 +71,7 @@ class ChatHandler:
             CodeAssistantAgent,
             WebSearchAgent,
             VoiceReplacementAgent,
+            VideoUnderstandingAgent,
             PricingAgent,
         ]
 

--- a/backend/director/tools/twelvelabs_tool.py
+++ b/backend/director/tools/twelvelabs_tool.py
@@ -1,0 +1,115 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+# Default models. Pegasus powers video understanding/analysis, Marengo powers
+# multimodal embeddings. These can be overridden through the agent config.
+PEGASUS_MODEL = "pegasus1.5"
+MARENGO_MODEL = "marengo3.0"
+
+PARAMS_CONFIG = {
+    "analyze": {
+        "model_name": {
+            "type": "string",
+            "description": "TwelveLabs Pegasus model to use for video analysis",
+            "default": PEGASUS_MODEL,
+            "enum": ["pegasus1.5", "pegasus1.2"],
+        },
+        "temperature": {
+            "type": "number",
+            "description": "Sampling temperature for the generated text",
+            "minimum": 0,
+            "maximum": 1,
+        },
+        "max_tokens": {
+            "type": "integer",
+            "description": "Maximum number of tokens to generate",
+            "default": 2048,
+        },
+    },
+    "embed": {
+        "model_name": {
+            "type": "string",
+            "description": "TwelveLabs Marengo model to use for embeddings",
+            "default": MARENGO_MODEL,
+            "enum": ["marengo3.0"],
+        },
+    },
+}
+
+
+class TwelveLabsTool:
+    """Thin wrapper around the official ``twelvelabs`` SDK.
+
+    Exposes the two TwelveLabs foundation models used by Director:
+    Pegasus for video understanding/analysis and Marengo for multimodal
+    embeddings.
+    """
+
+    def __init__(self, api_key: str):
+        if not api_key:
+            raise Exception("TwelveLabs API key not found")
+        # Imported lazily so the dependency is only required when the
+        # TwelveLabs engine is actually selected.
+        from twelvelabs import TwelveLabs
+
+        self.client = TwelveLabs(api_key=api_key)
+
+    def analyze_video(
+        self,
+        video_url: str,
+        prompt: str,
+        config: dict = None,
+    ) -> str:
+        """Analyze a video from a public URL using Pegasus.
+
+        TwelveLabs fetches the video server-side from ``video_url``.
+
+        :param str video_url: Publicly accessible URL of the video to analyze.
+        :param str prompt: The instruction guiding the analysis.
+        :param dict config: Optional overrides (``model_name``, ``temperature``,
+            ``max_tokens``).
+        :return: The generated text analysis.
+        :rtype: str
+        """
+        from twelvelabs import VideoContext_Url
+
+        config = config or {}
+        try:
+            response = self.client.analyze(
+                model_name=config.get("model_name", PEGASUS_MODEL),
+                video=VideoContext_Url(url=video_url),
+                prompt=prompt,
+                temperature=config.get("temperature"),
+                max_tokens=config.get("max_tokens", 2048),
+            )
+        except Exception as e:
+            raise Exception(
+                f"Error analyzing video with TwelveLabs: {type(e).__name__}: {str(e)}"
+            )
+        return response.data
+
+    def get_text_embedding(self, text: str, config: dict = None) -> list:
+        """Create a multimodal embedding for a text query using Marengo.
+
+        The returned vector lives in the same embedding space as
+        TwelveLabs video embeddings, so it can be used for text-to-video
+        retrieval.
+
+        :param str text: The text to embed.
+        :param dict config: Optional overrides (``model_name``).
+        :return: A list of floats (512-dimensional vector).
+        :rtype: list
+        """
+        config = config or {}
+        try:
+            response = self.client.embed.create(
+                model_name=config.get("model_name", MARENGO_MODEL),
+                text=text,
+            )
+        except Exception as e:
+            raise Exception(
+                f"Error creating embedding with TwelveLabs: {type(e).__name__}: {str(e)}"
+            )
+        return response.text_embedding.segments[0].float_

--- a/backend/director/tools/twelvelabs_tool.py
+++ b/backend/director/tools/twelvelabs_tool.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +61,7 @@ class TwelveLabsTool:
         self,
         video_url: str,
         prompt: str,
-        config: dict = None,
+        config: Optional[dict] = None,
     ) -> str:
         """Analyze a video from a public URL using Pegasus.
 
@@ -86,11 +87,11 @@ class TwelveLabsTool:
             )
         except Exception as e:
             raise Exception(
-                f"Error analyzing video with TwelveLabs: {type(e).__name__}: {str(e)}"
-            )
+                f"Error analyzing video with TwelveLabs: {type(e).__name__}: {e}"
+            ) from e
         return response.data
 
-    def get_text_embedding(self, text: str, config: dict = None) -> list:
+    def get_text_embedding(self, text: str, config: Optional[dict] = None) -> list:
         """Create a multimodal embedding for a text query using Marengo.
 
         The returned vector lives in the same embedding space as
@@ -110,6 +111,6 @@ class TwelveLabsTool:
             )
         except Exception as e:
             raise Exception(
-                f"Error creating embedding with TwelveLabs: {type(e).__name__}: {str(e)}"
-            )
+                f"Error creating embedding with TwelveLabs: {type(e).__name__}: {e}"
+            ) from e
         return response.text_embedding.segments[0].float_

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,3 +17,4 @@ replicate==1.0.1
 yt-dlp==2024.10.7
 videodb==0.3.0
 slack_sdk==3.33.2
+twelvelabs==1.2.8

--- a/backend/tests/test_twelvelabs_tool.py
+++ b/backend/tests/test_twelvelabs_tool.py
@@ -1,0 +1,84 @@
+"""Tests for the TwelveLabs tool wrapper.
+
+The unit tests stub the SDK client and run without network access. The
+embedding test is gated on ``TWELVELABS_API_KEY`` and is skipped when the key
+is not set, so the default test run requires no credentials.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from director.tools.twelvelabs_tool import (
+    TwelveLabsTool,
+    PARAMS_CONFIG,
+    PEGASUS_MODEL,
+    MARENGO_MODEL,
+)
+
+
+def test_requires_api_key():
+    with pytest.raises(Exception):
+        TwelveLabsTool(api_key="")
+
+
+def test_params_config_shape():
+    assert "analyze" in PARAMS_CONFIG
+    assert "embed" in PARAMS_CONFIG
+    assert PARAMS_CONFIG["analyze"]["model_name"]["default"] == PEGASUS_MODEL
+    assert PARAMS_CONFIG["embed"]["model_name"]["default"] == MARENGO_MODEL
+
+
+def _tool_with_mock_client():
+    """Build a TwelveLabsTool whose SDK client is a MagicMock (no network)."""
+    with patch("twelvelabs.TwelveLabs"):
+        tool = TwelveLabsTool(api_key="dummy-key")
+    tool.client = MagicMock()
+    return tool
+
+
+def test_analyze_video_wiring():
+    tool = _tool_with_mock_client()
+    tool.client.analyze.return_value = MagicMock(data="A cat plays the piano.")
+
+    result = tool.analyze_video(
+        video_url="https://example.com/video.mp4",
+        prompt="Describe this video",
+        config={"max_tokens": 1024},
+    )
+
+    assert result == "A cat plays the piano."
+    _, kwargs = tool.client.analyze.call_args
+    assert kwargs["model_name"] == PEGASUS_MODEL
+    assert kwargs["prompt"] == "Describe this video"
+    assert kwargs["max_tokens"] == 1024
+    # The video must be passed as a URL VideoContext.
+    assert kwargs["video"].url == "https://example.com/video.mp4"
+
+
+def test_get_text_embedding_wiring():
+    tool = _tool_with_mock_client()
+    segment = MagicMock(float_=[0.1, 0.2, 0.3])
+    tool.client.embed.create.return_value = MagicMock(
+        text_embedding=MagicMock(segments=[segment])
+    )
+
+    vector = tool.get_text_embedding("a cat")
+
+    assert vector == [0.1, 0.2, 0.3]
+    _, kwargs = tool.client.embed.create.call_args
+    assert kwargs["model_name"] == MARENGO_MODEL
+    assert kwargs["text"] == "a cat"
+
+
+@pytest.mark.skipif(
+    not os.getenv("TWELVELABS_API_KEY"),
+    reason="TWELVELABS_API_KEY not set; skipping live TwelveLabs call",
+)
+def test_marengo_text_embedding_live():
+    tool = TwelveLabsTool(api_key=os.environ["TWELVELABS_API_KEY"])
+    vector = tool.get_text_embedding("a cat playing the piano")
+    assert isinstance(vector, list)
+    assert len(vector) == 512
+    assert all(isinstance(v, float) for v in vector)


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## What this adds
A new opt-in **`video_understanding`** agent that analyzes a VideoDB video with **TwelveLabs Pegasus** for true multimodal understanding — grounded in the actual footage (scenes, objects, on-screen actions) and audio, not just the spoken-word transcript. It complements the existing `summarize_video` agent, which reasons over the transcript only.

It also adds a small `TwelveLabsTool` wrapper (`director/tools/twelvelabs_tool.py`) exposing:
- **Pegasus** video analysis (`analyze_video`)
- **Marengo** multimodal embeddings (`get_text_embedding`, 512-dim) — same embedding space as TwelveLabs video embeddings, useful for text-to-video retrieval.

The agent resolves a downloadable URL from the VideoDB stream and lets TwelveLabs fetch it server-side, mirroring how the existing `download`/generation agents work.

## Why it helps
Director already mixes multiple GenAI APIs per task. Pegasus gives the reasoning engine a way to *watch* a video — answering questions about visual content that a transcript can't (e.g. "what products appear?", "describe the b-roll"), which is a capability gap today.

## Opt-in / non-breaking
- Gated entirely on the `TWELVELABS_API_KEY` env var. When it's unset the agent simply reports an error; no defaults change and no existing agent is touched.
- Wired into `handler.py` and `requirements.txt` the same way existing tools/agents are; added to `.env.sample` and the README feature list.

## How it was tested
- Added `backend/tests/test_twelvelabs_tool.py`: no-network unit tests (SDK mocked) for the analyze/embed wiring, plus a live Marengo embedding test gated on `TWELVELABS_API_KEY` (skipped when unset).
- `pytest` → 5 passed (including a live Marengo call returning a 512-dim vector against the real API).
- `ruff check` and `black --check` clean on the changed files.
- Verified `director.handler` imports and the agent registers.
- Pinned `twelvelabs==1.2.8` (signatures introspected against the installed SDK).

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multimodal video understanding so the assistant can analyze videos (visual + audio) using TwelveLabs Pegasus.
* **Documentation**
  * Updated the README to highlight the new multimodal video understanding capability.
  * Added a TwelveLabs API key placeholder to the sample environment configuration.
* **Tests**
  * Added automated tests for the TwelveLabs wrapper, including validation, SDK call wiring, and an optional live embedding test when credentials are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->